### PR TITLE
Added password reset feature

### DIFF
--- a/src/controllers/authController.js
+++ b/src/controllers/authController.js
@@ -4,7 +4,7 @@ import { Toolbox, Mailer } from '../utils';
 
 const {
   successResponse, errorResponse, createToken, comparePassword,
-  verifyToken
+  verifyToken, hashPassword
 } = Toolbox;
 const {
   sendVerificationEmail
@@ -99,6 +99,29 @@ export default class AuthController {
       successResponse(res, { message: 'Successfully logged in via Google' }, 200);
     } catch (error) {
       errorResponse(res, { code: error.status, message: error.message });
+    }
+  }
+
+  /**
+   * reset user password
+   * @param {object} req
+   * @param {object} res
+   * @returns {JSON} - a JSON response
+   */
+  static async resetPassword(req, res) {
+    try {
+      const { password } = req.body;
+      const hasedhPassword = hashPassword(password);
+      const { id } = req.tokenData;
+      const user = await updateBykey({ password: hasedhPassword }, { id });
+      if (user) {
+        successResponse(res, { message: 'Password has been changed successfully' });
+      }
+    } catch (error) {
+      if (error.message === 'Not Found') {
+        return errorResponse(res, { code: 404, message: 'Sorry, we do not recognise this user in our database' });
+      }
+      errorResponse(res, {});
     }
   }
 }

--- a/src/routes/auth.js
+++ b/src/routes/auth.js
@@ -6,11 +6,11 @@ import { AuthController } from '../controllers';
 
 const router = Router();
 const {
-  onSignup, onLogin
+  onSignup, onLogin, onPasswordReset, authenticate,
 } = AuthMiddleware;
 
 const {
-  signup, login, verifyEmail, socialLogin
+  signup, login, verifyEmail, socialLogin, resetPassword
 } = AuthController;
 
 router.post('/signup', onSignup, signup);
@@ -20,5 +20,6 @@ router.get('/google', passport.authenticate('google', { scope: ['email', 'profil
 router.get('/google/callback',
   passport.authenticate('google'),
   socialLogin);
+router.post('/reset-password', authenticate, onPasswordReset, resetPassword);
 
 export default router;

--- a/src/test/auth.test.js
+++ b/src/test/auth.test.js
@@ -118,3 +118,59 @@ describe('Authentication route for email verification \n GET/v1.0/api/auth/verif
     expect(response.body.error.message).to.equal('Sorry, we do not recognise this user in our database');
   });
 });
+
+describe('Authentication routes for password reset \n POST /v1.0/api/auth/reset-password', () => {
+  it('should return a success response of 200 when a password has been reset', async () => {
+    const { token } = userInDatabase;
+    const resetValues = { password: 'defc34.Ase', confirmPassword: 'defc34.Ase' };
+    const response = await chai
+      .request(server)
+      .post('/v1.0/api/auth/reset-password')
+      .set('Cookie', `token=${token};`)
+      .send(resetValues);
+    expect(response).to.have.status(200);
+    expect(response.body.status).to.equal('success');
+    expect(response.body.data).to.be.a('object');
+    expect(response.body.data.message).to.be.a('string');
+    expect(response.body.data.message).to.equal('Password has been changed successfully');
+  });
+  it('should return a 400 error when password validation does not pass', async () => {
+    const { token } = userInDatabase;
+    const resetValues = { password: 'defc34.Ase', confirmPassword: 'defc34.Dse' };
+    const response = await chai
+      .request(server)
+      .post('/v1.0/api/auth/reset-password')
+      .set('Cookie', `token=${token};`)
+      .send(resetValues);
+    expect(response).to.have.status(400);
+    expect(response.body.status).to.equal('fail');
+    expect(response.body.error.message).to.equal('Please make sure the passwords match');
+  });
+  it('should return a 401 error when no token is detected', async () => {
+    const response = await chai
+      .request(server)
+      .post('/v1.0/api/auth/reset-password')
+      .set('Cookie', 'token=;');
+    expect(response).to.have.status(401);
+    expect(response.body.error.message).to.equal('Access denied, Token required');
+  });
+  it('should return a 400 error when an invalid token is detected', async () => {
+    const response = await chai
+      .request(server)
+      .post('/v1.0/api/auth/reset-password')
+      .set('Cookie', 'token=sdfrfvrfvr546;');
+    expect(response).to.have.status(400);
+    expect(response.body.error.message).to.equal('We could not verify your email, the token provided was invalid');
+  });
+  it('should return a 404 error if user in token does not exist', async () => {
+    const token = createToken({ id: 70 });
+    const resetValues = { password: 'defc34.Dse', confirmPassword: 'defc34.Dse' };
+    const response = await chai
+      .request(server)
+      .post('/v1.0/api/auth/reset-password')
+      .set('Cookie', `token=${token};`)
+      .send(resetValues);
+    expect(response).to.have.status(404);
+    expect(response.body.error.message).to.equal('Sorry, we do not recognise this user in our database');
+  });
+});

--- a/src/validations/index.js
+++ b/src/validations/index.js
@@ -1,4 +1,5 @@
 import AuthValidation from './authValidation';
+import PasswordValidation from './passwordValidation';
 
 
-export { AuthValidation };
+export { AuthValidation, PasswordValidation };

--- a/src/validations/passwordValidation.js
+++ b/src/validations/passwordValidation.js
@@ -1,0 +1,32 @@
+import Joi from '@hapi/joi';
+import passwordComplexity from 'joi-password-complexity';
+
+const complexityOPtions = {
+  min: 8,
+  max: 250,
+  lowerCase: 1,
+  upperCase: 1,
+  numeric: 1,
+  symbol: 1,
+  requirementCount: 3,
+};
+export const passwordResetEmailSchema = Joi.object().keys({
+  email: Joi.string()
+    .email()
+    .required()
+});
+
+export const changePasswordSchema = Joi.object().keys({
+  password: new passwordComplexity(complexityOPtions)
+    .required(),
+  confirmPassword: Joi.string()
+    .valid(Joi.ref('password'))
+    .required()
+    .options({
+      language: {
+        any: {
+          allowOnly: 'Passwords do not match!',
+        }
+      }
+    })
+});

--- a/swagger.json
+++ b/swagger.json
@@ -27,10 +27,6 @@
         {
             "name": "Auth",
             "description": "Endpoint for Authentication"
-        },
-        {
-            "name": "Users",
-            "description": "Endpoint for Users"
         }
     ],
     "paths": {
@@ -103,6 +99,44 @@
                     },
                     "404": {
                         "description": "User with email does not exists"
+                    },
+                    "500": {
+                        "description": "Internal Server Error"
+                    }
+                }
+            }
+        },
+        "auth/reset-password": {
+            "post": {
+                "description": "reset password of a logged in user",
+                "summary": "A user that's logged in should be able to reset his/her password",
+                "tags": [
+                    "Auth"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "security": [],
+                "parameters": [
+                    {
+                        "in": "body",
+                        "name": "body",
+                        "required": true,
+                        "description": "This is the request body object containing password reset information",
+                        "schema": {
+                            "$ref": "#/requestBody/passwordReset"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Passwords changed succesfully"
+                    },
+                    "401": {
+                        "description": "invalid inputs"
+                    },
+                    "404": {
+                        "description": "User does not exists"
                     },
                     "500": {
                         "description": "Internal Server Error"
@@ -203,6 +237,27 @@
                 },
             "required": [
                 "email, password"
+            ]
+        },
+        "passwordReset": {
+            "title": "User password reset request",
+            "type": "object",
+            "properties": {
+                "password": {
+                    "description": "The new Password of the user",
+                    "type": "string"
+                },
+                "confirmPassword": {
+                    "description": "The new Password of the user",
+                    "type": "string"
+                }
+            },
+            "example": {
+                "password": "defc34.Ase",
+                "confirmPassword": "defc34.Asedd"
+            },
+            "required": [
+                "password, confirmPassword"
             ]
         }
     }


### PR DESCRIPTION
### PR Overview
This PR adds a user password reset feature. A user that's logged in should be able to reset his/her password

Also added
- Password reset middleware
- Password validation
- Password reset controller
- auth tests

### Testing
- Clone the repo and cd into the project folder
- Update or copy `.env` file from `.env.sample`
- Checkout to `ft-user-search` branch and run `npm install`
- - Run `npm run migrate:reset` && `npm run migrate` to create tables in your 
 database and seed the database tables with the necessary app configs.
- Run `docker-compose up --build` to build the docker image and spin up all the necessary services
- As an alternative to running the app on docker, you can run `npm run start:dev`
- Launch `http://localhost:3000/v1.0/api/auth/reset-password`on Postman, make sure a user is already logged in with his/her token in the cookies.
 - input object type
```
{
	"password": "defc34.Ase",
	"confirmPassword": "defc34.Asedd"
}
```

### Screenshots

<img width="957" alt="Screenshot 2019-10-11 at 13 11 45" src="https://user-images.githubusercontent.com/37340699/66654038-3c41ab00-ec31-11e9-80f5-252848e7a9f9.png">
<img width="952" alt="Screenshot 2019-10-11 at 13 14 27" src="https://user-images.githubusercontent.com/37340699/66654048-41065f00-ec31-11e9-9052-1b014de0abeb.png">

