### PR TITLE
Added Reset Password via Email Feature

### DIFF
--- a/src/middlewares/authMiddleware.js
+++ b/src/middlewares/authMiddleware.js
@@ -1,7 +1,7 @@
 import { AuthValidation } from '../validations';
 import { Toolbox } from '../utils';
 import { UserService } from '../services';
-import { changePasswordSchema } from '../validations/passwordValidation';
+import { changePasswordSchema, passwordResetEmailSchema } from '../validations/passwordValidation';
 
 const {
   errorResponse, checkToken, verifyToken, validate
@@ -79,7 +79,13 @@ export default class AuthMiddleware {
    */
   static async onPasswordReset(req, res, next) {
     try {
-      const { error } = validate(req.body, changePasswordSchema);
+      let schema;
+      if (req.body.email) {
+        schema = passwordResetEmailSchema;
+      } else {
+        schema = changePasswordSchema;
+      }
+      const { error } = validate(req.body, schema);
       if (error) {
         const message = 'Please make sure the passwords match';
         return errorResponse(res, { code: 400, message });
@@ -107,7 +113,7 @@ export default class AuthMiddleware {
       next();
     } catch (error) {
       if (error.message === 'Invalid Token') {
-        return errorResponse(res, { code: 400, message: 'We could not verify your email, the token provided was invalid' });
+        return errorResponse(res, { code: 400, message: 'The token provided was invalid' });
       }
       errorResponse(res, {});
     }

--- a/src/routes/auth.js
+++ b/src/routes/auth.js
@@ -10,7 +10,8 @@ const {
 } = AuthMiddleware;
 
 const {
-  signup, login, verifyEmail, socialLogin, resetPassword
+  signup, login, verifyEmail, socialLogin, resetPassword, resetPasswordByEmail,
+  verifyPasswordReset
 } = AuthController;
 
 router.post('/signup', onSignup, signup);
@@ -21,5 +22,7 @@ router.get('/google/callback',
   passport.authenticate('google'),
   socialLogin);
 router.post('/reset-password', authenticate, onPasswordReset, resetPassword);
+router.post('/reset-password/email', onPasswordReset, resetPasswordByEmail);
+router.get('/reset-password/email', verifyPasswordReset);
 
 export default router;

--- a/src/test/auth.test.js
+++ b/src/test/auth.test.js
@@ -160,7 +160,7 @@ describe('Authentication routes for password reset \n POST /v1.0/api/auth/reset-
       .post('/v1.0/api/auth/reset-password')
       .set('Cookie', 'token=sdfrfvrfvr546;');
     expect(response).to.have.status(400);
-    expect(response.body.error.message).to.equal('We could not verify your email, the token provided was invalid');
+    expect(response.body.error.message).to.equal('The token provided was invalid');
   });
   it('should return a 404 error if user in token does not exist', async () => {
     const token = createToken({ id: 70 });
@@ -172,5 +172,31 @@ describe('Authentication routes for password reset \n POST /v1.0/api/auth/reset-
       .send(resetValues);
     expect(response).to.have.status(404);
     expect(response.body.error.message).to.equal('Sorry, we do not recognise this user in our database');
+  });
+});
+describe('Authentication routes for password reset email link \n GET /v1.0/api/auth/reset-password/emai?token=', () => {
+  it('should return an error if password reset link token is invalid', async () => {
+    const response = await chai
+      .request(server)
+      .get('/v1.0/api/auth/reset-password/email?token=sdfcvertgv9');
+    expect(response).to.have.status(400);
+    expect(response.body.error.message).to.equal('The token provided was invalid');
+  });
+  it('should return an error if password reset link token is not provided', async () => {
+    const response = await chai
+      .request(server)
+      .get('/v1.0/api/auth/reset-password/email?token=');
+    expect(response).to.have.status(400);
+    expect(response.body.error.message).to.equal('The token provided was invalid');
+  });
+  it('should return a success when a password reset link has been verified', async () => {
+    const { token } = userInDatabase;
+    const response = await chai
+      .request(server)
+      .get(`/v1.0/api/auth/reset-password/email?token=${token}`);
+    expect(response).to.have.status(200);
+    expect(response.body.status).to.equal('success');
+    expect(response.body.data).to.be.a('object');
+    expect(response.body.data.message).to.be.a('string');
   });
 });

--- a/src/utils/mailer.js
+++ b/src/utils/mailer.js
@@ -6,7 +6,7 @@ const {
   ADMIN_EMAIL, SENDGRID_KEY
 } = env;
 const {
-  createVerificationLink
+  createVerificationLink, createPasswordResetLink
 } = Toolbox;
 
 sendgrid.setApiKey(SENDGRID_KEY);
@@ -22,7 +22,7 @@ export default class Mailer {
    * Send email verification to user after signup
    * @param {object} req
    * @param {object} user - { id, email, firstName ...etc}
-   * @returns {Promise<boolean>} - Returns true if mail is send, false if not
+   * @returns {Promise<boolean>} - Returns true if mail is sent, false if not
    * @memberof Mailer
    */
   static async sendVerificationEmail(req, user) {
@@ -35,6 +35,33 @@ export default class Mailer {
       dynamic_template_data: {
         name: firstName,
         verification_link: verificationLink
+      }
+    };
+    try {
+      await sendgrid.send(mail);
+      return true;
+    } catch (e) {
+      return false;
+    }
+  }
+
+  /**
+   * Send password reset email
+   * @param {object} req
+   * @param {object} user
+   * @returns {Promise<boolean>} - Returns true if mail is sent, false if not
+   * @memberof Mailer
+   */
+  static async sendPasswordResetEmail(req, user) {
+    const { id, email, firstName } = user;
+    const passwordResetLink = createPasswordResetLink(req, { id, email });
+    const mail = {
+      to: email,
+      from: ADMIN_EMAIL,
+      templateId: 'd-b396458ad1754a639107fef49068c2fa',
+      dynamic_template_data: {
+        name: firstName,
+        reset_link: passwordResetLink
       }
     };
     try {

--- a/src/utils/toolbox.js
+++ b/src/utils/toolbox.js
@@ -130,6 +130,19 @@ export default class Toolbox {
   }
 
   /**
+   * Generates email password reset link
+   * @param {*} req
+   * @param {*} id
+   * @param {*} email
+   * @returns {URL} - password reset link
+   * @memberof Toolbox
+   */
+  static createPasswordResetLink(req, { id, email }) {
+    const token = Toolbox.createToken({ id, email }, '5h');
+    return `${req.protocol}://${req.get('host')}/v1.0/api/auth/reset-password/email?token=${token}`;
+  }
+
+  /**
    * Validates a value using the given Joi schema
    * @param {object} value
    * @param {Joi.SchemaLike} schema


### PR DESCRIPTION
### PR Overview
This PR adds a user password reset via email address feature. The application will send a user an email with a password reset link if the email given is registered to a user on our servers.

Also added
- mailer class for sendgrid methods
- password reset route
- password reset controller methods

### Testing
- Clone the repo and cd into the project folder
- Update or copy `.env` file from `.env.sample`
- Checkout to `ft-user-search` branch and run `npm install`
- - Run `npm run migrate:reset` && `npm run migrate` to create tables in your 
 database and seed the database tables with the necessary app configs.
- Run `docker-compose up --build` to build the docker image and spin up all the necessary services
- As an alternative to running the app on docker, you can run `npm run start:dev`
- Launch `http://localhost:3000/v1.0/api/auth/signup`on Postman
- Verification link created on a get request `localhost:3000/v1.0/api/auth/reset-password/email?token=[user-token]`

### Screenshot
<img width="1071" alt="Screenshot 2019-10-16 at 21 09 17" src="https://user-images.githubusercontent.com/37340699/66958206-97273800-f05f-11e9-9cfe-c1addd0d91d7.png">
<img width="1336" alt="Screenshot 2019-10-16 at 21 08 44" src="https://user-images.githubusercontent.com/37340699/66958214-9b535580-f05f-11e9-8d47-2d0002d2cde5.png">
