### PR TITLE
user can get his/her profile

### DIFF
--- a/src/controllers/userController.js
+++ b/src/controllers/userController.js
@@ -6,7 +6,7 @@ const {
 } = Toolbox;
 
 const {
-  updateBykey
+  updateBykey, findUser
 } = UserService;
 /**
  * Collection of classes cor controlling user profiles
@@ -25,6 +25,23 @@ export default class UserController {
       const id = req.params.userId;
       const user = await updateBykey(req.body, { id });
       successResponse(res, { message: 'Profile update was successful', user });
+    } catch (error) {
+      errorResponse(res, {});
+    }
+  }
+
+  /**
+   * get user profile
+   * @param {object} req
+   * @param {object} res
+   * @returns {JSON} - A jsom response with user details
+   * @memberof UserController
+   */
+  static async getProfile(req, res) {
+    try {
+      const id = req.params.userId;
+      const user = await findUser({ id });
+      successResponse(res, { user });
     } catch (error) {
       errorResponse(res, {});
     }

--- a/src/middlewares/userMiddleware.js
+++ b/src/middlewares/userMiddleware.js
@@ -19,7 +19,7 @@ export default class UserMiddleware {
    * @param {object} next
    * @returns {object} - return and object {error or response}
    */
-  static async onUpdateProfile(req, res, next) {
+  static async profileCheck(req, res, next) {
     try {
       const { userId } = req.params;
       const token = checkToken(req);

--- a/src/routes/user.js
+++ b/src/routes/user.js
@@ -1,11 +1,13 @@
 import { Router } from 'express';
 import { AuthMiddleware, UserMiddleware } from '../middlewares';
 import { UserController } from '../controllers';
+
 const router = Router();
 
 const { authenticate } = AuthMiddleware;
-const { onUpdateProfile } = UserMiddleware;
-const { updateProfile } = UserController;
-router.put('/profile/:userId', authenticate, onUpdateProfile, updateProfile);
+const { profileCheck } = UserMiddleware;
+const { updateProfile, getProfile } = UserController;
+router.put('/profile/:userId', authenticate, profileCheck, updateProfile);
+router.get('/profile/:userId', authenticate, profileCheck, getProfile);
 
 export default router;

--- a/swagger.json
+++ b/swagger.json
@@ -191,6 +191,45 @@
                     }
                 }
             }
+        },
+        "/user/profile/{userId}/": {
+            "get": {
+                "description": "get a users profile",
+                "summary": "User can get his profile from the database",
+                "tags": [
+                    "Users"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "security": [
+                    {
+                        "Bearer": []
+                    }
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "userId",
+                        "required": true,
+                        "description": "The id of the user"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Success"
+                    },
+                    "401": {
+                        "description": "Authorization required"
+                    },
+                    "404": {
+                        "description": "User Not Found"
+                    },
+                    "500": {
+                        "description": "Internal Server Error"
+                    }
+                }
+            }
         }
     },
     "requestBody": {


### PR DESCRIPTION
### PR Overview
This PR adds a user can get his/her profile feature

Also added
-  added controller method
- created route for getting profile
- edited swagger docs
- user tests

### Testing
- Clone the repo and cd into the project folder
- Update or copy `.env` file from `.env.sample`
- Checkout to `ft-user-search` branch and run `npm install`
- - Run `npm run migrate:reset` && `npm run migrate` to create tables in your 
 database and seed the database tables with the necessary app configs.
- Run `docker-compose up --build` to build the docker image and spin up all the necessary services
- As an alternative to running the app on docker, you can run `npm run start:dev`
- Launch a *GET* call for`http://localhost:3000/v1.0/api/user/profile/{id}`on Postman, make sure a user is already logged in with his/her token in the cookies.


### Screenshot
<img width="1071" alt="Screenshot 2019-10-17 at 09 55 53" src="https://user-images.githubusercontent.com/37340699/66994133-b310f500-f0c4-11e9-8bfe-5e8fb4c6ab43.png">

