### PR TITLE
Users can delete their account

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -14,6 +14,7 @@
     "sourceType": "module"
   },
   "rules": {
+    "linebreak-style": 0,
     "one-var": 0,
     "one-var-declaration-per-line": 0,
     "new-cap": 0,

--- a/src/controllers/authController.js
+++ b/src/controllers/authController.js
@@ -1,4 +1,3 @@
-/* eslint-disable linebreak-style */
 import { UserService } from '../services';
 import { Toolbox, Mailer } from '../utils';
 

--- a/src/controllers/userController.js
+++ b/src/controllers/userController.js
@@ -6,7 +6,7 @@ const {
 } = Toolbox;
 
 const {
-  updateBykey, findUser
+  updateBykey, findUser, deleteBykey
 } = UserService;
 /**
  * Collection of classes cor controlling user profiles
@@ -42,6 +42,26 @@ export default class UserController {
       const id = req.params.userId;
       const user = await findUser({ id });
       successResponse(res, { user });
+    } catch (error) {
+      errorResponse(res, {});
+    }
+  }
+
+  /**
+   * delete a user's account
+   * @param {object} req
+   * @param {object} res
+   * @returns {JSON } A JSON response with a message informing the user that the account has been deleted.
+   * @memberof UserController
+   */
+  static async deleteAccount(req, res) {
+    try {
+      const id = req.params.userId;
+      await deleteBykey({ id });
+      // Clear the token from the cookie
+      res.clearCookie('token', { maxAge: 70000000, httpOnly: true });
+      // Redirect back to home page after deleting the account
+      res.redirect(200, '/');
     } catch (error) {
       errorResponse(res, {});
     }

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,3 @@
-/* eslint-disable linebreak-style */
 /* eslint-disable no-unused-vars */
 import '@babel/polyfill';
 import express from 'express';

--- a/src/middlewares/userMiddleware.js
+++ b/src/middlewares/userMiddleware.js
@@ -1,11 +1,12 @@
 import { ProfileValidation } from '../validations';
 import { Toolbox } from '../utils';
+import { UserService } from '../services';
 
 const {
   errorResponse, checkToken, verifyToken
 } = Toolbox;
 const {
-  validateProfile
+  validateProfile, validateUserId
 } = ProfileValidation;
 /**
  * Middleware for user routes
@@ -29,6 +30,32 @@ export default class UserMiddleware {
         if (validated) next();
       } else {
         return errorResponse(res, { code: 401, message: 'Access denied, check your inputed details' });
+      }
+    } catch (error) {
+      errorResponse(res, { code: 400, message: error });
+    }
+  }
+
+  /**
+   * validate user account before deleting
+   * @param {object} req
+   * @param {object} res
+   * @param {object} next
+   * @returns {object} - return and object {error or response}
+   */
+  static async onDeleteAccount(req, res, next) {
+    try {
+      const userId = Number(req.params.userId);
+      await validateUserId(userId);
+      // Check if the user exixts
+      const user = await UserService.findUser({ id: userId });
+      if (!user) return errorResponse(res, { code: 400, message: 'User does not exist' });
+      const token = checkToken(req);
+      const tokenData = verifyToken(token);
+      if (tokenData.id === userId) {
+        next();
+      } else {
+        return errorResponse(res, { code: 401, message: 'Access denied, you can only delete your own account' });
       }
     } catch (error) {
       errorResponse(res, { code: 400, message: error });

--- a/src/routes/auth.js
+++ b/src/routes/auth.js
@@ -1,4 +1,3 @@
-/* eslint-disable linebreak-style */
 import { Router } from 'express';
 import passport from '../config/passport';
 import { AuthMiddleware } from '../middlewares';

--- a/src/routes/user.js
+++ b/src/routes/user.js
@@ -5,9 +5,11 @@ import { UserController } from '../controllers';
 const router = Router();
 
 const { authenticate } = AuthMiddleware;
-const { profileCheck } = UserMiddleware;
-const { updateProfile, getProfile } = UserController;
+const { profileCheck, onDeleteAccount } = UserMiddleware;
+const { updateProfile, getProfile, deleteAccount } = UserController;
 router.put('/profile/:userId', authenticate, profileCheck, updateProfile);
 router.get('/profile/:userId', authenticate, profileCheck, getProfile);
+router.put('/profile/:userId', authenticate, profileCheck, updateProfile);
+router.delete('/account/:userId', authenticate, onDeleteAccount, deleteAccount);
 
 export default router;

--- a/src/routes/user.js
+++ b/src/routes/user.js
@@ -9,7 +9,6 @@ const { profileCheck, onDeleteAccount } = UserMiddleware;
 const { updateProfile, getProfile, deleteAccount } = UserController;
 router.put('/profile/:userId', authenticate, profileCheck, updateProfile);
 router.get('/profile/:userId', authenticate, profileCheck, getProfile);
-router.put('/profile/:userId', authenticate, profileCheck, updateProfile);
-router.delete('/account/:userId', authenticate, onDeleteAccount, deleteAccount);
+router.delete('/:userId', authenticate, onDeleteAccount, deleteAccount);
 
 export default router;

--- a/src/services/userService.js
+++ b/src/services/userService.js
@@ -44,4 +44,16 @@ export default class UserService {
     if (!rowaffected) throw new ApiError(404, 'Not Found');
     return user.dataValues;
   }
+
+  /**
+   * delete user key given an option
+   * @param {object} keys - query key to delete
+   * @returns {promise-object | error} A number showing how many rows were deleted
+   * @memberof UserService
+   */
+  static async deleteBykey(keys) {
+    const numberOfRowsDeleted = await User.destroy({ where: keys });
+    if (!numberOfRowsDeleted) throw new ApiError(404, 'Not Found');
+    return true;
+  }
 }

--- a/src/test/dummyData.js
+++ b/src/test/dummyData.js
@@ -35,6 +35,21 @@ export const anotherUser = {
   phoneNumber: '+2349055679332'
 };
 
+export const anotherUser2 = {
+  firstName: 'joh',
+  lastName: 'chang',
+  email: 'user2@gmail.com',
+  password: 'biyyP4U.ee',
+  gender: 'male',
+  birthDate: '1994-04-16',
+  addressLine1: 'No 34, cintro street',
+  addressLine2: 'Northpoint drive Allen',
+  city: 'Gidi',
+  state: 'Lagos',
+  country: 'Nigeria',
+  phoneNumber: '+2349055679332'
+};
+
 
 export const userInDatabase = async (body) => {
   const user = await addUser({ ...body });

--- a/src/test/user.test.js
+++ b/src/test/user.test.js
@@ -2,7 +2,7 @@ import chai, { expect } from 'chai';
 import chaiHttp from 'chai-http';
 import server from '..';
 import { Toolbox } from '../utils';
-import { anotherUser, userInDatabase } from './dummyData';
+import { anotherUser, userInDatabase, anotherUser2 } from './dummyData';
 
 const { createToken } = Toolbox;
 
@@ -78,5 +78,40 @@ describe('User route get profile \n GET /v1.0/api/user/profile/{id}', () => {
     expect(response).to.have.status(401);
     expect(response.body.status).to.equal('fail');
     expect(response.body.error.message).to.equal('Access denied, Token required');
+  });
+});
+
+describe('A user can delete their account', () => {
+  let user2;
+  it('should successfully delete a logged in user\'s account', async () => {
+    user2 = await userInDatabase(anotherUser2);
+    const response = await chai
+      .request(server)
+      .delete(`/v1.0/api/user/account/${user2.id}`)
+      .set('Cookie', `token=${user2.token};`);
+    expect(response).to.have.status(200);
+  });
+  it('should return an error if the userId is not in the proper format', async () => {
+    const response = await chai
+      .request(server)
+      .delete('/v1.0/api/user/account/djjs')
+      .set('Cookie', `token=${user2.token}`);
+    expect(response).to.have.status(400);
+    expect(response.body.status).to.equal('fail');
+  });
+  it('should return an error if the userId does not exist', async () => {
+    const response = await chai
+      .request(server)
+      .delete('/v1.0/api/user/account/500')
+      .set('Cookie', `token=${user2.token}`);
+    expect(response).to.have.status(400);
+  });
+  it('should return an error if a user tries to delete a profile that\'s not his/hers', async () => {
+    const response = await chai
+      .request(server)
+      .delete(`/v1.0/api/user/account/${user.id}`)
+      .set('Cookie', `token=${user2.token}`);
+    expect(response).to.have.status(401);
+    expect(response.body.status).to.equal('fail');
   });
 });

--- a/src/test/user.test.js
+++ b/src/test/user.test.js
@@ -87,14 +87,14 @@ describe('A user can delete their account', () => {
     user2 = await userInDatabase(anotherUser2);
     const response = await chai
       .request(server)
-      .delete(`/v1.0/api/user/account/${user2.id}`)
+      .delete(`/v1.0/api/user/${user2.id}`)
       .set('Cookie', `token=${user2.token};`);
     expect(response).to.have.status(200);
   });
   it('should return an error if the userId is not in the proper format', async () => {
     const response = await chai
       .request(server)
-      .delete('/v1.0/api/user/account/djjs')
+      .delete('/v1.0/api/user/djjs')
       .set('Cookie', `token=${user2.token}`);
     expect(response).to.have.status(400);
     expect(response.body.status).to.equal('fail');
@@ -102,14 +102,14 @@ describe('A user can delete their account', () => {
   it('should return an error if the userId does not exist', async () => {
     const response = await chai
       .request(server)
-      .delete('/v1.0/api/user/account/500')
+      .delete('/v1.0/api/user/500')
       .set('Cookie', `token=${user2.token}`);
     expect(response).to.have.status(400);
   });
   it('should return an error if a user tries to delete a profile that\'s not his/hers', async () => {
     const response = await chai
       .request(server)
-      .delete(`/v1.0/api/user/account/${user.id}`)
+      .delete(`/v1.0/api/user/${user.id}`)
       .set('Cookie', `token=${user2.token}`);
     expect(response).to.have.status(401);
     expect(response.body.status).to.equal('fail');

--- a/src/validations/profileValidation.js
+++ b/src/validations/profileValidation.js
@@ -34,4 +34,18 @@ export default class ProfileValidation {
     if (error) throw error.details[0].context.label;
     return true;
   }
+
+  /**
+   * object for vvalidation user id
+   * @param {number} id - user id
+   * @returns {object | boolean} - returns an error object or valid boolean
+   */
+  static async validateUserId(id) {
+    const schema = {
+      id: joi.number().integer().min(1),
+    };
+    const { error } = joi.validate({ id }, schema);
+    if (error) throw error.details[0].context.label;
+    return true;
+  }
 }

--- a/swagger.json
+++ b/swagger.json
@@ -231,7 +231,7 @@
                 }
             }
         },
-        "/user/account/{userId}": {
+        "/user/{userId}": {
             "delete": {
                 "description": "Deletes a single user profile",
                 "summary": "Users can delete their profile",

--- a/swagger.json
+++ b/swagger.json
@@ -230,6 +230,42 @@
                     }
                 }
             }
+        },
+        "/user/account/{userId}": {
+            "delete": {
+                "description": "Deletes a single user profile",
+                "summary": "Users can delete their profile",
+                "tags": [
+                    "Users"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "security": [
+                    {
+                        "Bearer": []
+                    }
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "userId",
+                        "required": true,
+                        "description": "The Id of the user to be delete"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Success"
+                    },
+                    "400": {
+                        "description": "Bad request"
+                    },
+                    "401": {
+                        "description": "Authorization required"
+                    }
+                }
+            }
         }
     },
     "requestBody": {


### PR DESCRIPTION
#### What does this PR do?
- Implements the feature to enable users to delete their accounts

#### Description of Task to be completed?
- Implement routes, authentication middleware, validation function and controllers
- Test routes using Postman
- Write unite tests
- Update the endpoint on the swagger doc

#### How should this be manually tested?
- Clone the Repo.
- On the terminal enter `npm run start:dev`
- Open postman and register a user through the sign-up route (Take note of your userId)
- Navigate to the DELETE endpoint localhost:3000/v1.0/api/user/account/:userId
- Enter your userId in the path variable listed above and initiate the request

#### Any background context you want to provide?
- Right now other features have not been implemented which will allow users to make requests that will leave residual data. Later on, we need to come back strategize on how far the deleting of an account will go.

- We would want to respect our users' wishes and delete all personal info/or data footprint relating to them, but then again records crucial to us such as order details would be important to us as well.
#### What are the relevant pivotal tracker stories?
