### PR TITLE
implement feature to allow admins add ingredients

### DIFF
--- a/src/controllers/index.js
+++ b/src/controllers/index.js
@@ -1,7 +1,9 @@
 import AuthController from './authController';
 import UserController from './userController';
+import IngredientController from './ingredietController';
 
 export {
   AuthController,
-  UserController
+  UserController,
+  IngredientController,
 };

--- a/src/controllers/ingredietController.js
+++ b/src/controllers/ingredietController.js
@@ -1,0 +1,31 @@
+import { IngredientService } from '../services';
+import { Toolbox } from '../utils';
+
+const {
+  successResponse, errorResponse,
+} = Toolbox;
+
+const { addIngredient } = IngredientService;
+
+/**
+ * Ingredients Controller
+ * @class IngredientController
+ */
+export default class IngredientController {
+  /**
+   * add a new ingredient
+   * @param {object} req
+   * @param {object} res
+   * @returns {JSON } A JSON response with the user's profile details.
+   * @memberof IngredientController
+   */
+  static async addIngredient(req, res) {
+    const { name, unit } = req.body;
+    try {
+      const addedIngredient = await addIngredient({ name, unit });
+      successResponse(res, { message: 'Ingredient added successfully', addedIngredient }, 201);
+    } catch (error) {
+      errorResponse(res, {});
+    }
+  }
+}

--- a/src/middlewares/index.js
+++ b/src/middlewares/index.js
@@ -1,7 +1,9 @@
 import AuthMiddleware from './authMiddleware';
 import UserMiddleware from './userMiddleware';
+import IngredientMiddleware from './ingredientMiddleware';
 
 export {
   AuthMiddleware,
-  UserMiddleware
+  UserMiddleware,
+  IngredientMiddleware,
 };

--- a/src/middlewares/ingredientMiddleware.js
+++ b/src/middlewares/ingredientMiddleware.js
@@ -1,0 +1,31 @@
+import { IngredientValidations } from '../validations';
+import { Toolbox } from '../utils';
+import { IngredientService } from '../services';
+
+const { errorResponse } = Toolbox;
+const { addIngredientValidation } = IngredientValidations;
+const { findIngredient } = IngredientService;
+/**
+ * Middleware for ingredient routes
+ * @class IngredientMiddleware
+ */
+export default class IngredientMiddleware {
+  /**
+   * validate request before adding ingredients
+   * @param {object} req
+   * @param {object} res
+   * @param {object} next
+   * @returns {object} - return and object {error or response}
+   */
+  static async onAddIngredient(req, res, next) {
+    const { name, unit } = req.body;
+    try {
+      addIngredientValidation({ name, unit });
+      const ingredientExists = await findIngredient({ name });
+      if (ingredientExists) return errorResponse(res, { code: 400, message: 'ingredient already exists' });
+      next();
+    } catch (error) {
+      errorResponse(res, { code: 400, message: error });
+    }
+  }
+}

--- a/src/migrations/20191021152722-create-ingredient.js
+++ b/src/migrations/20191021152722-create-ingredient.js
@@ -1,0 +1,32 @@
+
+module.exports = {
+  up: (queryInterface, Sequelize) => queryInterface.createTable('Ingredients', {
+    id: {
+      allowNull: false,
+      autoIncrement: true,
+      primaryKey: true,
+      type: Sequelize.INTEGER
+    },
+    name: {
+      type: Sequelize.STRING,
+      allowNull: false,
+    },
+    unit: {
+      type: Sequelize.STRING,
+      allowNull: false,
+    },
+    price: {
+      type: Sequelize.DOUBLE,
+      allowNull: true,
+    },
+    createdAt: {
+      allowNull: false,
+      type: Sequelize.DATE
+    },
+    updatedAt: {
+      allowNull: false,
+      type: Sequelize.DATE
+    }
+  }),
+  down: (queryInterface) => queryInterface.dropTable('Ingredients')
+};

--- a/src/models/ingredient.js
+++ b/src/models/ingredient.js
@@ -1,0 +1,18 @@
+module.exports = (sequelize, DataTypes) => {
+  const Ingredient = sequelize.define('Ingredient', {
+    name: {
+      type: DataTypes.STRING,
+      unique: true,
+    },
+    unit: {
+      type: DataTypes.STRING,
+    },
+    price: {
+      type: DataTypes.DOUBLE
+    },
+  }, {});
+  Ingredient.associate = (models) => {
+    // associations can be defined here
+  };
+  return Ingredient;
+};

--- a/src/routes/index.js
+++ b/src/routes/index.js
@@ -3,10 +3,12 @@ import swaggerUi from 'swagger-ui-express';
 import swaggerDocument from '../../swagger.json';
 import authRoutes from './auth';
 import userRoutes from './user';
+import ingredientRoutes from './ingredient';
 
 const router = Router();
 router.use('/auth', authRoutes);
 router.use('/user', userRoutes);
+router.use('/ingredient', ingredientRoutes);
 router.use('/docs', swaggerUi.serve);
 router.get('/docs', swaggerUi.setup(swaggerDocument));
 

--- a/src/routes/ingredient.js
+++ b/src/routes/ingredient.js
@@ -1,0 +1,16 @@
+import { Router } from 'express';
+import { AuthMiddleware, UserMiddleware, IngredientMiddleware } from '../middlewares';
+import { IngredientController } from '../controllers';
+import { PermissionsData } from '../utils';
+
+const router = Router();
+
+const { authenticate, isVerified } = AuthMiddleware;
+const { verifyRoles } = UserMiddleware;
+const { onAddIngredient } = IngredientMiddleware;
+const { addIngredient } = IngredientController;
+const { admin } = PermissionsData;
+
+router.post('/', authenticate, verifyRoles(admin), isVerified, onAddIngredient, addIngredient);
+
+export default router;

--- a/src/services/index.js
+++ b/src/services/index.js
@@ -1,7 +1,9 @@
 import UserService from './userService';
 import RoleService from './roleService';
+import IngredientService from './ingredientService';
 
 export {
   UserService,
-  RoleService
+  RoleService,
+  IngredientService,
 };

--- a/src/services/ingredientService.js
+++ b/src/services/ingredientService.js
@@ -1,0 +1,63 @@
+import { ApiError } from '../utils';
+import db from '../models';
+
+const { Ingredient } = db;
+
+/**
+ * Service interface for Ingredient db model
+ */
+export default class IngredientService {
+  /**
+   * Add new ingredient to database
+   * @static
+   * @param {object} ingredient - new ingredient object
+   * @returns {Promis-Object} A promise object with ingredient details
+   * @memberof IngredientService
+   */
+  static async addIngredient(ingredient) {
+    try {
+      const { dataValues: addedIngredient } = await Ingredient.create(ingredient);
+      return addedIngredient;
+    } catch (error) {
+      throw new Error(error);
+    }
+  }
+
+  /**
+   * find ingredient in database
+   * @param {object} keys - object containing query key and value
+   * e.g { id: 5 }
+   * @returns {promise-Object} - A promise object with ingredient details
+   * @memberof UserService
+   */
+  static async findIngredient(keys) {
+    return Ingredient.findOne({ where: keys });
+  }
+
+  /**
+   * update ingredient key given an option
+   * @param {object} updateData - data to update
+   * @param {object} keys - query key to update
+   * @returns {promise-object | error} A promise object with ingredient detail
+   * @memberof UserService
+   */
+  static async updateBykey(updateData, keys) {
+    const [rowaffected, [ingredient]] = await Ingredient.update(
+      updateData, { returning: true, where: keys }
+    );
+    if (!rowaffected) throw new ApiError(404, 'Not Found');
+    return ingredient.dataValues;
+  }
+
+  /**
+   * delete ingredient key given an option
+   * @param {object} keys - query key to delete
+   * @returns {promise-object | error} A number showing how many rows were deleted
+   * @memberof UserService
+   */
+  static async deleteBykey(keys) {
+    const numberOfRowsDeleted = await Ingredient.destroy({ where: keys });
+    if (!numberOfRowsDeleted) throw new ApiError(404, 'Not Found');
+    return true;
+  }
+}

--- a/src/test/dummyData.js
+++ b/src/test/dummyData.js
@@ -1,9 +1,10 @@
 /* eslint-disable import/no-extraneous-dependencies */
-import { UserService, RoleService } from '../services';
+import { UserService, RoleService, IngredientService } from '../services';
 import { Toolbox } from '../utils';
 
-const { addUser } = UserService;
+const { addUser, updateBykey, deleteBykey } = UserService;
 const { assignRole } = RoleService;
+const { addIngredient } = IngredientService;
 const { createToken } = Toolbox;
 
 export const newUser = {
@@ -65,10 +66,49 @@ export const thirdUser = {
   phoneNumber: '+2349055679332'
 };
 
+export const userA = {
+  firstName: 'joh',
+  lastName: 'chang',
+  email: 'userA@gmail.com',
+  password: 'biyyP4U.ee',
+  gender: 'male',
+  birthDate: '1994-04-16',
+  addressLine1: 'No 34, cintro street',
+  addressLine2: 'Northpoint drive Allen',
+  city: 'Gidi',
+  state: 'Lagos',
+  country: 'Nigeria',
+  phoneNumber: '+2349055679332'
+};
+
+export const userB = {
+  firstName: 'joh',
+  lastName: 'chang',
+  email: 'userB@gmail.com',
+  password: 'biyyP4U.ee',
+  gender: 'male',
+  birthDate: '1994-04-16',
+  addressLine1: 'No 34, cintro street',
+  addressLine2: 'Northpoint drive Allen',
+  city: 'Gidi',
+  state: 'Lagos',
+  country: 'Nigeria',
+  phoneNumber: '+2349055679332'
+};
+
 
 export const userInDatabase = async (body, roleId = 2) => {
   const user = await addUser({ ...body });
+  await updateBykey({ isVerified: true }, { id: user.id });
   await assignRole(user.id, roleId);
   user.token = createToken({ email: user.email, id: user.id, roleId });
   return user;
+};
+
+export const addIngredientToDb = async (ingredient) => {
+  await addIngredient(ingredient);
+};
+
+export const removeUserFromDb = async (id) => {
+  await deleteBykey(id);
 };

--- a/src/test/ingredient.test.js
+++ b/src/test/ingredient.test.js
@@ -1,0 +1,60 @@
+import chai, { expect } from 'chai';
+import chaiHttp from 'chai-http';
+import server from '..';
+import {
+  userA, userB, userInDatabase, addIngredientToDb, removeUserFromDb
+} from './dummyData';
+
+chai.use(chaiHttp);
+
+describe('Admin can add ingredients', () => {
+  let normalUser;
+  let adminUser;
+  before(async () => {
+    normalUser = await userInDatabase(userA, 3);
+    adminUser = await userInDatabase(userB, 2);
+    await addIngredientToDb({ name: 'test', unit: '1 gram' });
+  });
+  after(async () => {
+    await removeUserFromDb({ id: normalUser.id });
+    await removeUserFromDb({ id: adminUser.id });
+  });
+  it('should successfully add an ingredient', async () => {
+    const response = await chai
+      .request(server)
+      .post('/v1.0/api/ingredient')
+      .set('Cookie', `token=${adminUser.token};`)
+      .send({ name: 'tomato', unit: '1 gram' });
+    expect(response).to.have.status(201);
+    expect(response.body.status).to.equal('success');
+    expect(response.body.data).to.be.a('object');
+    expect(response.body.data.message).to.be.a('string');
+  });
+  it('should return an error if the user is not an admin', async () => {
+    const response = await chai
+      .request(server)
+      .post('/v1.0/api/ingredient')
+      .set('Cookie', `token=${normalUser.token};`)
+      .send({ name: 'tomato', unit: '1 gram' });
+    expect(response).to.have.status(403);
+    expect(response.body.status).to.equal('fail');
+  });
+  it('should return a validation error if the inputs are entered in the wrong format', async () => {
+    const response = await chai
+      .request(server)
+      .post('/v1.0/api/ingredient')
+      .set('Cookie', `token=${adminUser.token};`)
+      .send({ name: 'tomato', unit: 5 });
+    expect(response).to.have.status(400);
+    expect(response.body.status).to.equal('fail');
+  });
+  it('should return an error if the ingredient name already exists', async () => {
+    const response = await chai
+      .request(server)
+      .post('/v1.0/api/ingredient')
+      .set('Cookie', `token=${adminUser.token};`)
+      .send({ name: 'test', unit: '1 gram' });
+    expect(response).to.have.status(400);
+    expect(response.body.status).to.equal('fail');
+  });
+});

--- a/src/validations/index.js
+++ b/src/validations/index.js
@@ -1,10 +1,12 @@
 import AuthValidation from './authValidation';
 import PasswordValidation from './passwordValidation';
 import ProfileValidation from './profileValidation';
+import IngredientValidations from './ingredientValidation';
 
 
 export {
   AuthValidation,
   PasswordValidation,
-  ProfileValidation
+  ProfileValidation,
+  IngredientValidations,
 };

--- a/src/validations/ingredientValidation.js
+++ b/src/validations/ingredientValidation.js
@@ -1,0 +1,28 @@
+import joi from '@hapi/joi';
+
+const name = joi.string().min(3).max(30).required()
+  .label('Please enter a valid name \n the field must not be empty and it must be more than 2 letters');
+const unit = joi.string().min(3).max(60).regex(/^\d+\s(gram|grams|litre|litres)$/i)
+  .required()
+  .label('Please enter a valid unit starting with a digit and ending with either gram, grams, litre or litres. A space should separate the number and unit');
+
+/**
+ * validation class for Ingredients
+ * @class IngredientValidations
+ */
+export default class IngredientValidations {
+  /**
+   * object for adding ingredients
+   * @param {object} payload - object to be validated
+   * @returns {object | boolean} - returns an error object or valid boolean
+   */
+  static addIngredientValidation(payload) {
+    const schema = {
+      name,
+      unit,
+    };
+    const { error } = joi.validate({ ...payload }, schema);
+    if (error) throw error.details[0].context.label;
+    return true;
+  }
+}


### PR DESCRIPTION
#### What does this PR do?
- This PR implements the feature to allow admins to add ingredients

#### Description of Task to be completed?
- Create ingredients migration and model files
- Create ingredients service
- Create endpoint allowing only admins

#### How should this be manually tested?
- Clone the repo
- On your terminal enter `npm start:dev`
- Open up postman
- Create a `POST` request to the endpoint `localhost:3000/v1.0/api/ingredient`
- The request body must have `name` and `unit` both of type `string`. `name` being the name of the ingredient and unit being the amount in weight or volume that represents a unit of that ingredient
- The `unit` must follow the form `x gram` , `x grams`, `x litre`, `x litres`. Where `x` is a number

#### Any background context you want to provide?
- In the future, a feature should be created for the bulk addition of ingredients

### Algorithm
- A request is sent in to add a new ingredient to the ingredients table
- The request body will contain attributes, `name` and `unit`
- The attributes are validated through regex, `name` is the name of the ingredient and `unit` the amount in weight or volume that makes a unit
- The ingredients database is checked to see if an ingredient with the same name exists; if it does respond with a bad request
- The ingredient is then added to the database