### PR TITLE
Added Meal Category Feature

### DIFF
--- a/src/controllers/mealController.js
+++ b/src/controllers/mealController.js
@@ -1,4 +1,4 @@
-import { MealService } from '../services';
+import { MealService, CategoryService } from '../services';
 import { Toolbox } from '../utils';
 
 
@@ -7,8 +7,9 @@ const {
 } = Toolbox;
 
 const {
-  addMeal, getAllMeals, addIngredientToMeal
+  addMeal, getAllMeals, addIngredientToMeal,
 } = MealService;
+const { addCategory, addMealToCategory } = CategoryService;
 
 /**
  * Meal Controller
@@ -59,6 +60,38 @@ export default class MealController {
       const allMeals = await getAllMeals();
       if (!allMeals.length) return errorResponse(res, { code: 404, message: 'There are no meals' });
       return successResponse(res, { ...allMeals });
+    } catch (error) {
+      errorResponse(res, {});
+    }
+  }
+
+  /**
+   * add meal category
+   * @param {object} req
+   * @param {object} res
+   * @returns {JSON } A JSON response with the meal category.
+   * @memberof MealController
+   */
+  static async newCategory(req, res) {
+    try {
+      const addedCategory = await addCategory(req.body);
+      successResponse(res, { message: 'Category added successfully', addedCategory });
+    } catch (error) {
+      errorResponse(res, {});
+    }
+  }
+
+  /**
+   * add meal to category
+   * @param {object} req
+   * @param {object} res
+   * @returns {JSON } A JSON response.
+   * @memberof MealController
+   */
+  static async addMealToCategory(req, res) {
+    try {
+      const mealCategory = await addMealToCategory(req.body);
+      successResponse(res, { message: 'Meal added to category successfully', mealCategory });
     } catch (error) {
       errorResponse(res, {});
     }

--- a/src/middlewares/mealMiddleware.js
+++ b/src/middlewares/mealMiddleware.js
@@ -1,10 +1,13 @@
 import { MealValidation } from '../validations';
 import { Toolbox } from '../utils';
-import { MealService, IngredientService } from '../services';
+import { MealService, IngredientService, CategoryService } from '../services';
 
-const { validateMeal, validateMealParameters } = MealValidation;
+const {
+  validateMeal, validateMealParameters, validateCategory, validateCategoryParameters
+} = MealValidation;
 const { findMeal } = MealService;
 const { findIngredient } = IngredientService;
+const { findCategory } = CategoryService;
 const { errorResponse } = Toolbox;
 /**
  * Middleware for meal routes
@@ -47,6 +50,48 @@ export default class MealMiddleware {
       if (!mealExists) return errorResponse(res, { code: 404, message: 'meal does not exist in our database' });
       const ingredient = await findIngredient({ id: ingredientId });
       if (!ingredient) return errorResponse(res, { code: 404, message: 'ingredient does not exist in our database' });
+      next();
+    } catch (error) {
+      errorResponse(res, { code: 400, message: error });
+    }
+  }
+
+  /**
+   * validate category of a meal
+   * @param {object} req
+   * @param {object} res
+   * @param {object} next
+   * @returns {object} - return and object {error or response}
+   * @memberof MealMiddleware
+   */
+  static async onMealCategory(req, res, next) {
+    try {
+      validateCategory(req.body);
+      const { category } = req.body;
+      const categoryExists = await findCategory({ category });
+      if (categoryExists) return errorResponse(res, { code: 400, message: 'category already exists' });
+      next();
+    } catch (error) {
+      errorResponse(res, { code: 400, message: error });
+    }
+  }
+
+  /**
+   * validate meal being added to category
+   * @param {object} req
+   * @param {object} res
+   * @param {object} next
+   * @returns {object} - return and object {error or response}
+   * @memberof MealMiddleware
+   */
+  static async mealCategoryCheck(req, res, next) {
+    try {
+      const { mealId, categoryId } = req.body;
+      validateCategoryParameters(req.body);
+      const mealExists = await findMeal({ id: mealId });
+      if (!mealExists) return errorResponse(res, { code: 404, message: 'meal does not exist in our database' });
+      const category = await findCategory({ id: categoryId });
+      if (!category) return errorResponse(res, { code: 404, message: 'category does not exist in our database' });
       next();
     } catch (error) {
       errorResponse(res, { code: 400, message: error });

--- a/src/middlewares/mealMiddleware.js
+++ b/src/middlewares/mealMiddleware.js
@@ -7,7 +7,7 @@ const {
 } = MealValidation;
 const { findMeal } = MealService;
 const { findIngredient } = IngredientService;
-const { findCategory } = CategoryService;
+const { findCategory, findMealByCategory } = CategoryService;
 const { errorResponse } = Toolbox;
 /**
  * Middleware for meal routes
@@ -92,6 +92,8 @@ export default class MealMiddleware {
       if (!mealExists) return errorResponse(res, { code: 404, message: 'meal does not exist in our database' });
       const category = await findCategory({ id: categoryId });
       if (!category) return errorResponse(res, { code: 404, message: 'category does not exist in our database' });
+      const mealInCategory = await findMealByCategory(categoryId, mealId);
+      if (mealInCategory) return errorResponse(res, { code: 400, message: 'This meal is already in this category' });
       next();
     } catch (error) {
       errorResponse(res, { code: 400, message: error });

--- a/src/migrations/20191028192024-create-category.js
+++ b/src/migrations/20191028192024-create-category.js
@@ -1,0 +1,27 @@
+module.exports = {
+  up: (queryInterface, Sequelize) => queryInterface.createTable('Categories', {
+    id: {
+      allowNull: false,
+      autoIncrement: true,
+      primaryKey: true,
+      type: Sequelize.INTEGER
+    },
+    category: {
+      type: Sequelize.STRING,
+      allowNull: false,
+    },
+    description: {
+      type: Sequelize.STRING,
+      allowNull: true
+    },
+    createdAt: {
+      allowNull: false,
+      type: Sequelize.DATE
+    },
+    updatedAt: {
+      allowNull: false,
+      type: Sequelize.DATE
+    }
+  }),
+  down: (queryInterface) => queryInterface.dropTable('Categories')
+};

--- a/src/migrations/20191028192542-create-mealcategory.js
+++ b/src/migrations/20191028192542-create-mealcategory.js
@@ -1,0 +1,40 @@
+module.exports = {
+  up: (queryInterface, Sequelize) => queryInterface.createTable('MealCategories', {
+    id: {
+      allowNull: false,
+      autoIncrement: true,
+      primaryKey: true,
+      type: Sequelize.INTEGER
+    },
+    mealId: {
+      type: Sequelize.INTEGER,
+      allowNull: false,
+      references: {
+        model: 'Meals',
+        key: 'id'
+      },
+      onUpdate: 'CASCADE',
+      onDelete: 'CASCADE'
+    },
+    categoryId: {
+      type: Sequelize.INTEGER,
+      allowNull: false,
+      references: {
+        model: 'Categories',
+        key: 'id'
+      },
+      onUpdate: 'CASCADE',
+      onDelete: 'CASCADE'
+    },
+    createdAt: {
+      allowNull: false,
+      type: Sequelize.DATE
+    },
+    updatedAt: {
+      allowNull: false,
+      type: Sequelize.DATE
+    }
+  }),
+
+  down: (queryInterface) => queryInterface.dropTable('MealCategories')
+};

--- a/src/models/category.js
+++ b/src/models/category.js
@@ -1,0 +1,20 @@
+module.exports = (sequelize, DataTypes) => {
+  const Category = sequelize.define('Category', {
+    category: {
+      type: DataTypes.STRING,
+      unique: true,
+    },
+    description: {
+      type: DataTypes.STRING,
+      allowNull: true
+    },
+  }, {});
+  Category.associate = (models) => {
+    Category.belongsToMany(models.Meal, {
+      through: 'MealCategories',
+      as: 'meals',
+      foreignKey: 'categoryId'
+    });
+  };
+  return Category;
+};

--- a/src/models/meal.js
+++ b/src/models/meal.js
@@ -27,6 +27,11 @@ module.exports = (sequelize, DataTypes) => {
       as: 'ingredients',
       foreignKey: 'mealId'
     });
+    Meal.belongsToMany(models.Category, {
+      through: 'MealCategories',
+      as: 'categories',
+      foreignKey: 'mealId'
+    });
   };
   return Meal;
 };

--- a/src/models/mealCategory.js
+++ b/src/models/mealCategory.js
@@ -1,0 +1,28 @@
+module.exports = (sequelize, DataTypes) => {
+  const MealCategory = sequelize.define('MealCategory', {
+    mealId: {
+      type: DataTypes.INTEGER,
+      allowNull: false,
+      references: {
+        model: 'Meal',
+        key: 'id'
+      },
+      onUpdate: 'CASCADE',
+      onDelete: 'CASCADE'
+    },
+    categoryId: {
+      type: DataTypes.INTEGER,
+      allowNull: false,
+      references: {
+        model: 'Category',
+        key: 'id'
+      },
+      onUpdate: 'CASCADE',
+      onDelete: 'CASCADE'
+    },
+  }, {});
+  MealCategory.associate = () => {
+
+  };
+  return MealCategory;
+};

--- a/src/routes/meal.js
+++ b/src/routes/meal.js
@@ -7,11 +7,18 @@ const router = Router();
 
 const { authenticate, isVerified } = AuthMiddleware;
 const { verifyRoles } = UserMiddleware;
-const { mealCheck, ingredientCheck } = MealMiddleware;
-const { newMeal, addIngredientToMeal, viewMeals } = MealController;
+const {
+  mealCheck, ingredientCheck, onMealCategory, mealCategoryCheck
+} = MealMiddleware;
+const {
+  newMeal, addIngredientToMeal, viewMeals, newCategory, addMealToCategory
+} = MealController;
 const { admin } = PermissionsData;
 router.post('/', authenticate, verifyRoles(admin), isVerified, mealCheck, newMeal);
 router.post('/add-ingredient', authenticate, verifyRoles(admin), isVerified, ingredientCheck, addIngredientToMeal);
 router.get('/', authenticate, verifyRoles(admin), isVerified, viewMeals);
+router.post('/category/', authenticate, verifyRoles(admin), isVerified, onMealCategory, newCategory);
+router.post('/category/add-meal', authenticate, verifyRoles(admin), isVerified, mealCategoryCheck, addMealToCategory);
+
 
 export default router;

--- a/src/services/categoryService.js
+++ b/src/services/categoryService.js
@@ -79,4 +79,15 @@ export default class CategoryService {
       throw new Error(error);
     }
   }
+
+  /**
+   * find meal by meal category
+   * @param {object} categoryId
+   * @param {object} mealId
+   * @returns {promise-object} - meal in category
+   * @memberof CategoryService
+   */
+  static async findMealByCategory(categoryId, mealId) {
+    return MealCategory.findOne({ where: mealId, categoryId });
+  }
 }

--- a/src/services/categoryService.js
+++ b/src/services/categoryService.js
@@ -1,0 +1,82 @@
+import { ApiError } from '../utils';
+import db from '../models';
+
+
+const {
+  Category, MealCategory,
+} = db;
+
+/**
+ * Services for meal categories db model
+ * @class CategoryService
+ */
+export default class CategoryService {
+  /**
+   * add category
+   * @static
+   * @param {object} category
+   * @returns {Promis-Object} A promise object with category details
+   * @memberof CategoryService
+   */
+  static async addCategory(category) {
+    try {
+      const { dataValues: value } = await Category.create(category);
+      return value;
+    } catch (error) {
+      throw new Error(error);
+    }
+  }
+
+  /**
+   * find a category
+   * @param {object} keys - object containing query key and value
+   * e.g { id: 5 }
+   * @returns {promise-Object} - A promise object with category details
+   * @memberof CategoryService
+   */
+  static async findCategory(keys) {
+    return Category.findOne({ where: keys });
+  }
+
+  /**
+   * update a category given a key
+   * @param {object} updateData - data to update
+   * @param {object} keys - query key to update
+   * @returns {promise-object | error} A promise object with category detail
+   * @memberof CategoryService
+   */
+  static async updateCategoryBykey(updateData, keys) {
+    const [rowaffected, [category]] = await Category.update(
+      updateData, { returning: true, where: keys }
+    );
+    if (!rowaffected) throw new ApiError(404, 'Not Found');
+    return category.dataValues;
+  }
+
+  /**
+   * delete a category
+   * @param {object} keys - query key to delete
+   * @returns {promise-object | error} A number showing how many rows were deleted
+   * @memberof CategoryService
+   */
+  static async deleteCategoryBykey(keys) {
+    const numberOfRowsDeleted = await Category.destroy({ where: keys });
+    if (!numberOfRowsDeleted) throw new ApiError(404, 'Not Found');
+    return true;
+  }
+
+  /**
+   * add meal to category
+   * @param {object} payload - { mealId, categoryId }
+   * @returns {promise-object} - updated category
+   * @memberof CategoryService
+   */
+  static async addMealToCategory(payload) {
+    try {
+      const { dataValues: value } = await MealCategory.create(payload);
+      return value;
+    } catch (error) {
+      throw new Error(error);
+    }
+  }
+}

--- a/src/services/index.js
+++ b/src/services/index.js
@@ -2,10 +2,12 @@ import UserService from './userService';
 import RoleService from './roleService';
 import IngredientService from './ingredientService';
 import MealService from './mealService';
+import CategoryService from './categoryService';
 
 export {
   UserService,
   RoleService,
   IngredientService,
-  MealService
+  MealService,
+  CategoryService
 };

--- a/src/test/dummyData.js
+++ b/src/test/dummyData.js
@@ -1,11 +1,15 @@
 /* eslint-disable import/no-extraneous-dependencies */
-import { UserService, RoleService, IngredientService, MealService } from '../services';
+import {
+  UserService, RoleService, IngredientService, MealService,
+  CategoryService
+} from '../services';
 import { Toolbox } from '../utils';
 
 const { addUser, updateBykey, deleteBykey } = UserService;
 const { assignRole } = RoleService;
 const { addIngredient } = IngredientService;
 const { addMeal, addIngredientToMeal } = MealService;
+const { addCategory } = CategoryService;
 const { createToken } = Toolbox;
 
 export const newUser = {
@@ -126,5 +130,10 @@ export const addMealToDb = async (meal) => {
 
 export const addIngredientToMealInDb = async (payload) => {
   const value = await addIngredientToMeal(payload);
+  return value;
+};
+
+export const addCategoryToDb = async (category) => {
+  const value = await addCategory(category);
   return value;
 };

--- a/src/test/meal.test.js
+++ b/src/test/meal.test.js
@@ -32,6 +32,7 @@ describe('Admin can add meals and add ingredients to meals', () => {
   after(async () => {
     await removeUserFromDb({ id: normalUser.id });
     await removeUserFromDb({ id: adminUser.id });
+    // await removeMealCategroyFromDb({ categoryId: category.id });
   });
   it('should successfully add a meal', async () => {
     const response = await chai
@@ -202,6 +203,19 @@ describe('Admin can add meals and add ingredients to meals', () => {
     expect(response.body.status).to.equal('success');
     expect(response.body.data).to.be.a('object');
     expect(response.body.data.message).to.be.a('string');
+  });
+  it('should return an error if input meal has been added to input category', async () => {
+    const response = await chai
+      .request(server)
+      .post('/v1.0/api/meal/category/add-meal')
+      .set('Cookie', `token=${adminUser.token};`)
+      .send({
+        mealId: meal.id,
+        categoryId: category.id,
+      });
+    expect(response).to.have.status(400);
+    expect(response.body.status).to.equal('fail');
+    expect(response.body.error.message).to.equal('This meal is already in this category');
   });
   it('should return an error if a category does not exist', async () => {
     const response = await chai

--- a/src/test/meal.test.js
+++ b/src/test/meal.test.js
@@ -2,7 +2,8 @@ import chai, { expect } from 'chai';
 import chaiHttp from 'chai-http';
 import server from '..';
 import {
-  userA, userB, userInDatabase, addIngredientToDb, addMealToDb, removeUserFromDb
+  userA, userB, userInDatabase, addIngredientToDb, addMealToDb,
+  removeUserFromDb, addCategoryToDb
 } from './dummyData';
 
 chai.use(chaiHttp);
@@ -11,6 +12,7 @@ describe('Admin can add meals and add ingredients to meals', () => {
   let adminUser;
   let meal;
   let ingredient;
+  let category;
   before(async () => {
     normalUser = await userInDatabase(userA, 3);
     adminUser = await userInDatabase(userB, 2);
@@ -22,6 +24,10 @@ describe('Admin can add meals and add ingredients to meals', () => {
       imageUrl: 'https://images.com/jollof',
     });
     ingredient = await addIngredientToDb({ name: 'fish', unit: 'grams' });
+    category = await addCategoryToDb({
+      category: 'vegetarian',
+      description: 'Meals for the lovers of all things vegetarian',
+    });
   });
   after(async () => {
     await removeUserFromDb({ id: normalUser.id });
@@ -143,5 +149,84 @@ describe('Admin can add meals and add ingredients to meals', () => {
     expect(response).to.have.status(200);
     expect(response.body.status).to.equal('success');
     expect(response.body.data).to.be.a('object');
+  });
+  it('shoulf succesfully add a new meal category', async () => {
+    const response = await chai
+      .request(server)
+      .post('/v1.0/api/meal/category')
+      .set('Cookie', `token=${adminUser.token};`)
+      .send({
+        category: 'Keto Diet',
+        description: 'Meals for those on a keto diet',
+      });
+    expect(response).to.have.status(200);
+    expect(response.body.status).to.equal('success');
+    expect(response.body.data).to.be.a('object');
+    expect(response.body.data.message).to.be.a('string');
+  });
+  it('should return an error if category input is in wrong format', async () => {
+    const response = await chai
+      .request(server)
+      .post('/v1.0/api/meal/category')
+      .set('Cookie', `token=${adminUser.token};`)
+      .send({
+        category: 5,
+        description: 'Meals for those on a keto diet',
+      });
+    expect(response).to.have.status(400);
+    expect(response.body.status).to.equal('fail');
+  });
+  it('should return an error if category already exists', async () => {
+    const response = await chai
+      .request(server)
+      .post('/v1.0/api/meal/category')
+      .set('Cookie', `token=${adminUser.token};`)
+      .send({
+        category: 'Keto Diet',
+        description: 'Meals for those on a keto diet',
+      });
+    expect(response).to.have.status(400);
+    expect(response.body.status).to.equal('fail');
+    expect(response.body.error.message).to.equal('category already exists');
+  });
+  it('should succesfully add a meal to a category', async () => {
+    const response = await chai
+      .request(server)
+      .post('/v1.0/api/meal/category/add-meal')
+      .set('Cookie', `token=${adminUser.token};`)
+      .send({
+        mealId: meal.id,
+        categoryId: category.id,
+      });
+    expect(response).to.have.status(200);
+    expect(response.body.status).to.equal('success');
+    expect(response.body.data).to.be.a('object');
+    expect(response.body.data.message).to.be.a('string');
+  });
+  it('should return an error if a category does not exist', async () => {
+    const response = await chai
+      .request(server)
+      .post('/v1.0/api/meal/category/add-meal')
+      .set('Cookie', `token=${adminUser.token};`)
+      .send({
+        mealId: meal.id,
+        categoryId: 546,
+      });
+    expect(response).to.have.status(404);
+    expect(response.body.status).to.equal('fail');
+    expect(response.body.error.message).to.equal('category does not exist in our database');
+  });
+  it('shoulf return an error if meal does not exist', async () => {
+    const response = await chai
+      .request(server)
+      .post('/v1.0/api/meal/category/add-meal')
+      .set('Cookie', `token=${adminUser.token};`)
+      .send({
+        mealId: 4355,
+        categoryId: category.id,
+      });
+    expect(response).to.have.status(404);
+    expect(response.body.status).to.equal('fail');
+    expect(response.body.error.message).to.equal('meal does not exist in our database');
   });
 });

--- a/src/validations/mealValidation.js
+++ b/src/validations/mealValidation.js
@@ -9,6 +9,10 @@ const prepTime = joi.string().min(3).max(60).regex(/^\d+\s(hours|minutes)$/i)
   .label('Please enter a valid prep Time with format: \'x minutes\' or \'y hours\'');
 const imageUrl = joi.string().uri().required().label('Please upload an Image of the meal');
 const number = joi.number().positive().required().label('Please enter a positive number');
+const category = joi.string().min(3).max(30).required()
+  .label('Please enter a valid meal category \n the field must not be empty and it must be more than 2 letters');
+const description = joi.string().min(3).max(30).required()
+  .label('Please enter a description \n the field must not be empty and it must be more than 5 characters');
 /**
  * validation class for meals
  * @class MealValidation
@@ -44,6 +48,38 @@ export default class MealValidation {
       mealId: number,
       ingredientId: number,
       ingredientQuantity: number,
+    };
+    const { error } = joi.validate({ ...payload }, schema);
+    if (error) throw error.details[0].context.label;
+    return true;
+  }
+
+  /**
+   * validate caterory
+   * @param {object} payload
+   * @returns {object | boolean} - returns an error object or valid boolean
+   * @memberof MealValidation
+   */
+  static validateCategory(payload) {
+    const schema = {
+      category,
+      description,
+    };
+    const { error } = joi.validate({ ...payload }, schema);
+    if (error) throw error.details[0].context.label;
+    return true;
+  }
+
+  /**
+   * validation for parameters on add meal to category
+   * @param {object} payload
+   * @returns {object | boolean} - returns an error object or valid boolean
+   * @memberof MealValidation
+   */
+  static validateCategoryParameters(payload) {
+    const schema = {
+      mealId: number,
+      categoryId: number,
     };
     const { error } = joi.validate({ ...payload }, schema);
     if (error) throw error.details[0].context.label;

--- a/swagger.json
+++ b/swagger.json
@@ -568,7 +568,7 @@
                         "in": "body",
                         "name": "body",
                         "required": true,
-                        "description": "This is the request body object containing payloadvalues",
+                        "description": "This is the request body object containing payload values",
                         "schema": {
                             "$ref": "#/requestBody/meal-ingredient"
                         }
@@ -606,6 +606,90 @@
                     }
                 ],
                 "parameters": [],
+                "responses": {
+                    "200": {
+                        "description": "Success"
+                    },
+                    "400": {
+                        "description": "Bad request"
+                    },
+                    "404": {
+                        "description": "Not found"
+                    },
+                    "401": {
+                        "description": "Authorization required"
+                    }
+                }
+            }
+        },
+        "/meal/category": {
+            "post": {
+                "description": "Add a meal category",
+                "summary": "An admin can add a new meal category to the database",
+                "tags": [
+                    "Meal"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "security": [
+                    {
+                        "Bearer": []
+                    }
+                ],
+                "parameters": [
+                    {
+                        "in": "body",
+                        "name": "body",
+                        "required": true,
+                        "description": "This is the request body object containing category",
+                        "schema": {
+                            "$ref": "#/requestBody/add-category"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Success"
+                    },
+                    "400": {
+                        "description": "Bad request"
+                    },
+                    "404": {
+                        "description": "Not found"
+                    },
+                    "401": {
+                        "description": "Authorization required"
+                    }
+                }
+            }
+        },
+        "meal/category/add-meal": {
+            "post": {
+                "description": "Add a meal to a meal category",
+                "summary": "An admin can add a new meal to a meal category to the database",
+                "tags": [
+                    "Meal"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "security": [
+                    {
+                        "Bearer": []
+                    }
+                ],
+                "parameters": [
+                    {
+                        "in": "body",
+                        "name": "body",
+                        "required": true,
+                        "description": "This is the request body object containing payload values",
+                        "schema": {
+                            "$ref": "#/requestBody/meal-category"
+                        }
+                    }
+                ],
                 "responses": {
                     "200": {
                         "description": "Success"
@@ -881,6 +965,48 @@
             },
             "required": [
                 "mealId", "ingredientId", "ingredientQuantity"
+            ]
+        },
+        "add-category": {
+            "title": "add meal category in database",
+            "type": "object",
+            "properties": {
+                "category": {
+                    "description": "category name",
+                    "type": "string"
+                },
+                "description": {
+                    "description": "category description",
+                    "type": "string"
+                }
+            },
+            "example": {
+                "category": "Keto Diet",
+                "description": "A meal for those on keto diet"
+            },
+            "required": [
+                "category", "description"
+            ]
+        },
+        "meal-category": {
+            "title": "add meal to a meal category in database",
+            "type": "object",
+            "properties": {
+                "mealId": {
+                    "description": "meal id",
+                    "type": "integer"
+                },
+                "categoryId": {
+                    "description": "category id",
+                    "type": "integer"
+                }
+            },
+            "example": {
+                "mealId": 5,
+                "categoryId": 1
+            },
+            "required": [
+                "mealId", "categoryId"
             ]
         }
     }


### PR DESCRIPTION
## PR Overview
This PR adds features to allow an admin to add meal category, and add a meal to a category

Roles
- Admin
- user

Also added
-  admin validations
- routes for add category and meals, 
- created category services
- user tests

## Algorithms

### Algorithm for creating category
- The request body will contain the category details
- Services, middlewares and controllers will handle populating the categories table

### Algorithm for adding meal to category
- object with category id and meal id
- Services, middlewares and controllers will handle populating the mealCategories table

## Testing
- Clone the repo and cd into the project folder
- Update or copy `.env` file from `.env.sample`
- Checkout to `ft-user-search` branch and run `npm install`
- Run `npm run migrate:reset` && `npm run migrate` to create tables in your 
 database and seed the database tables with the necessary app configs.
- Run `docker-compose up --build` to build the docker image and spin up all the necessary services
- As an alternative to running the app on docker, you can run `npm run start:dev`

### POST for add meal category
-`http://localhost:3000/v1.0/api/meal/category` 
- make sure an admin is already logged in with his/her token in the cookies.
- object
```
{
        category: 'Keto Diet',
        description: 'Meals for those on a Keto diet',
{
```
### POST for add meal to a category
-`http://localhost:3000/v1.0/api/meal/category/add-meal` 
- make sure an admin is already logged in with his/her token in the cookies.
- object
```
{
        mealId: 1,
        categoryId: 1,
{
```
