### PR TITLE
add order client api and callback url

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "test": "cross-env NODE_ENV=test nyc --reporter=text --reporter=html mocha src/test/*.js --timeout 10000 -c --require @babel/register --exit",
     "coverage": "nyc report --reporter=text-lcov | coveralls",
-    "start": "node dist/index.js",
+    "start": "npm run migrate && npm run seed && node dist/index.js",
     "build": "babel src -d dist",
     "migrate": "sequelize db:migrate ",
     "migrate:reset": "sequelize db:migrate:undo:all",

--- a/src/controllers/orderController.js
+++ b/src/controllers/orderController.js
@@ -1,13 +1,16 @@
-import { OrderService } from '../services';
-import { Toolbox } from '../utils';
+import { OrderService, CartService, } from '../services';
+import { Toolbox, Payments } from '../utils';
 
 const {
   successResponse, errorResponse,
 } = Toolbox;
 
 const {
-  createOrder
+  createOrder, createDelivery
 } = OrderService;
+const {
+  deleteCartMealByKey,
+} = CartService;
 
 /**
  * Order Controller
@@ -15,22 +18,65 @@ const {
  */
 export default class OrderController {
   /**
-   * create a new order
+   * create a new order via client side
    * @param {object} req
    * @param {object} res
    * @returns {JSON } A JSON response with the created order.
    * @memberof OrderController
    */
-  static async createOrder(req, res) {
-    const { meals } = req.body;
-    const payload = {
-      userId: req.tokenData.id,
-      meals,
-      price: req.orderPrice,
-    };
+  static async clientOrder(req, res) {
+    const { reference } = req.query;
     try {
+      const { data } = await Payments.validatePaystack(reference);
+      if (data.status === 'failed' || data.status === 'abandoned') return errorResponse(res, { code: 400, message: `Payment error: ${data.gateway_response}` });
+      const { metadata } = data;
+      const payload = {
+        userId: req.tokenData.id,
+        meals: metadata.meals,
+        price: metadata.price,
+        reference,
+      };
       const createdOrder = await createOrder(payload);
-      successResponse(res, { message: 'order created', createdOrder }, 201);
+      await deleteCartMealByKey({ userId: req.tokenData.id });
+      const deliveryData = {
+        userId: metadata.userId,
+        orderId: createdOrder[0].orderId,
+        address: metadata.address,
+      };
+      const delivery = await createDelivery(deliveryData);
+      successResponse(res, { message: 'order created', createdOrder, delivery }, 201);
+    } catch (error) {
+      errorResponse(res, {});
+    }
+  }
+
+  /**
+   * create a new order via server side
+   * @param {object} req
+   * @param {object} res
+   * @returns {JSON } A JSON response with the created order.
+   * @memberof OrderController
+   */
+  static async serverOrder(req, res) {
+    const { data } = req.body;
+    if (data.status === 'failed' || data.status === 'abandoned') return errorResponse(res, { code: 400, message: `Payment error: ${data.gateway_response}` });
+    try {
+      const { metadata } = data;
+      const payload = {
+        userId: metadata.userId,
+        meals: metadata.meals,
+        price: metadata.price,
+        reference: data.reference,
+      };
+      const createdOrder = await createOrder(payload);
+      await deleteCartMealByKey({ userId: metadata.userId });
+      const deliveryData = {
+        userId: metadata.userId,
+        orderId: createdOrder[0].orderId,
+        address: metadata.address,
+      };
+      const delivery = await createDelivery(deliveryData);
+      successResponse(res, { message: 'order created', createdOrder, delivery }, 201);
     } catch (error) {
       errorResponse(res, {});
     }

--- a/src/controllers/payController.js
+++ b/src/controllers/payController.js
@@ -34,32 +34,32 @@ export default class PayController {
        * PLEASE UNCOMMENT ALL LINES BELOW BEFORE PRODUCTION
        * OR WHEN TESTING PAYSTACK API FOR YOURSELF
        */
-      // const mealsInCart = await getMealsInCart({ userId: req.tokenData.id });
-      // if (!mealsInCart.length) return errorResponse(res, { code: 404, message: 'There are no meals in your cart' });
-      // const meals = mealsInCart.map(({
-      //   id, userId, createdAt, updatedAt, ...items
-      // }) => items);
-      // const mealIds = meals.map((meal) => meal.mealId);
-      // const mealsInDatabase = await findMultipleMeals({ id: mealIds });
-      // const price = calculateOrderPrice(meals, mealsInDatabase);
-      // const metadata = {
-      //   userId: req.tokenData.id, meals, address, price,
-      // };
-      // const payload = {
-      //   email: req.tokenData.email,
-      //   amount: price * 100,
-      //   metadata,
-      // };
+      const mealsInCart = await getMealsInCart({ userId: req.tokenData.id });
+      if (!mealsInCart.length) return errorResponse(res, { code: 404, message: 'There are no meals in your cart' });
+      const meals = mealsInCart.map(({
+        id, userId, createdAt, updatedAt, ...items
+      }) => items);
+      const mealIds = meals.map((meal) => meal.mealId);
+      const mealsInDatabase = await findMultipleMeals({ id: mealIds });
+      const price = calculateOrderPrice(meals, mealsInDatabase);
+      const metadata = {
+        userId: req.tokenData.id, meals, address, price,
+      };
+      const payload = {
+        email: req.tokenData.email,
+        amount: price * 100,
+        metadata,
+      };
 
-      // const paystack = await Payments.viaPaystack(payload);
-      // if (!paystack.status) errorResponse(res, { code: 400, message: paystack.message });
-      // const url = paystack.data.authorization_url;
-      // successResponse(res, { message: `success, redirect to ${url}`, url });
+      const paystack = await Payments.viaPaystack(payload);
+      if (!paystack.status) errorResponse(res, { code: 400, message: paystack.message });
+      const url = paystack.data.authorization_url;
+      successResponse(res, { message: `success, redirect to ${url}`, url });
       /**
        * PLEASE DELETE SINGLE LINE BELOW BEFORE PRODUCTION
        * OR COMMENT WHEN TESTING PAYSTACK API FOR YOURSELF
        */
-      successResponse(res, { message: 'success, redirect to https://greenpot-api.herokuapp.com/v1.0/api/docs' });
+      // successResponse(res, { message: 'success, redirect to https://greenpot-api.herokuapp.com/v1.0/api/docs' });
     } catch (error) {
       if (error === 'Please enter a strring') return errorResponse(res, { code: 400, message: error });
       errorResponse(res, {});

--- a/src/controllers/payController.js
+++ b/src/controllers/payController.js
@@ -1,4 +1,3 @@
-import joi from '@hapi/joi';
 import { Toolbox, Payments } from '../utils';
 import { CartService, MealService } from '../services';
 import { PayValidation } from '../validations';

--- a/src/controllers/payController.js
+++ b/src/controllers/payController.js
@@ -1,8 +1,10 @@
+import joi from '@hapi/joi';
 import { Toolbox, Payments } from '../utils';
 import { CartService, MealService } from '../services';
+import { PayValidation } from '../validations';
 
 const {
-  successResponse, errorResponse, calculateOrderPrice
+  successResponse, errorResponse, calculateOrderPrice, validate,
 } = Toolbox;
 const {
   getMealsInCart,
@@ -10,6 +12,9 @@ const {
 const {
   findMultipleMeals,
 } = MealService;
+const {
+  validateParameters,
+} = PayValidation;
 /**
  * Pay Controller to hold methods for payment options
  * @memberof PayController
@@ -23,19 +28,28 @@ export default class PayController {
    * @memberof payController
    */
   static async withPaystack(req, res) {
+    const { address } = req.body;
     try {
+      validateParameters({ address });
       /**
        * PLEASE UNCOMMENT ALL LINES BELOW BEFORE PRODUCTION
        * OR WHEN TESTING PAYSTACK API FOR YOURSELF
        */
-      // const allMeals = await getMealsInCart({ userId: req.tokenData.id });
-      // if (!allMeals.length) return errorResponse(res, { code: 404, message: 'There are no meals in your cart' });
-      // const mealIds = allMeals.map((meal) => meal.mealId);
+      // const mealsInCart = await getMealsInCart({ userId: req.tokenData.id });
+      // if (!mealsInCart.length) return errorResponse(res, { code: 404, message: 'There are no meals in your cart' });
+      // const meals = mealsInCart.map(({
+      //   id, userId, createdAt, updatedAt, ...items
+      // }) => items);
+      // const mealIds = meals.map((meal) => meal.mealId);
       // const mealsInDatabase = await findMultipleMeals({ id: mealIds });
-      // const price = calculateOrderPrice(allMeals, mealsInDatabase);
+      // const price = calculateOrderPrice(meals, mealsInDatabase);
+      // const metadata = {
+      //   userId: req.tokenData.id, meals, address, price,
+      // };
       // const payload = {
       //   email: req.tokenData.email,
       //   amount: price * 100,
+      //   metadata,
       // };
 
       // const paystack = await Payments.viaPaystack(payload);
@@ -48,6 +62,7 @@ export default class PayController {
        */
       successResponse(res, { message: 'success, redirect to https://greenpot-api.herokuapp.com/v1.0/api/docs' });
     } catch (error) {
+      if (error === 'Please enter a strring') return errorResponse(res, { code: 400, message: error });
       errorResponse(res, {});
     }
   }

--- a/src/migrations/20191220172052-create-deliver-order.js
+++ b/src/migrations/20191220172052-create-deliver-order.js
@@ -1,0 +1,43 @@
+module.exports = {
+  up: (queryInterface, Sequelize) => queryInterface.createTable('DeliverOrders', {
+    id: {
+      allowNull: false,
+      autoIncrement: true,
+      primaryKey: true,
+      type: Sequelize.INTEGER
+    },
+    userId: {
+      type: Sequelize.INTEGER,
+      allowNull: false,
+      references: {
+        model: 'Users',
+        key: 'id'
+      },
+      onUpdate: 'CASCADE',
+      onDelete: 'CASCADE'
+    },
+    orderId: {
+      type: Sequelize.INTEGER,
+      allowNull: false,
+      references: {
+        model: 'Orders',
+        key: 'id'
+      },
+      onUpdate: 'CASCADE',
+      onDelete: 'CASCADE'
+    },
+    address: {
+      type: Sequelize.STRING,
+      allowNull: true
+    },
+    createdAt: {
+      allowNull: false,
+      type: Sequelize.DATE
+    },
+    updatedAt: {
+      allowNull: false,
+      type: Sequelize.DATE
+    }
+  }),
+  down: (queryInterface) => queryInterface.dropTable('DeliverOrders')
+};

--- a/src/migrations/20191221102937-modify-orders-table-add-paystackReference.js
+++ b/src/migrations/20191221102937-modify-orders-table-add-paystackReference.js
@@ -1,0 +1,8 @@
+
+module.exports = {
+  up: (queryInterface, Sequelize) => queryInterface.addColumn('Orders', 'paystackReference', {
+    type: Sequelize.STRING,
+    allowNull: true,
+  }),
+  down: (queryInterface) => queryInterface.removeColumn('Orders', 'paystackReference')
+};

--- a/src/models/deliverOrder.js
+++ b/src/models/deliverOrder.js
@@ -1,0 +1,31 @@
+module.exports = (sequelize, DataTypes) => {
+  const DeliverOrder = sequelize.define('DeliverOrder', {
+    userId: {
+      type: DataTypes.INTEGER,
+      allowNull: false,
+      references: {
+        model: 'User',
+        key: 'id'
+      },
+      onUpdate: 'CASCADE',
+      onDelete: 'CASCADE'
+    },
+    orderId: {
+      type: DataTypes.INTEGER,
+      allowNull: false,
+      references: {
+        model: 'Order',
+        key: 'id'
+      },
+      onUpdate: 'CASCADE',
+      onDelete: 'CASCADE'
+    },
+    address: {
+      type: DataTypes.STRING,
+      allowNull: true
+    },
+  }, {});
+  DeliverOrder.associate = () => {
+  };
+  return DeliverOrder;
+};

--- a/src/models/order.js
+++ b/src/models/order.js
@@ -18,6 +18,10 @@ module.exports = (sequelize, DataTypes) => {
     price: {
       type: DataTypes.DOUBLE,
       allowNull: true
+    },
+    paystackReference: {
+      type: DataTypes.STRING,
+      allowNull: true
     }
   }, {});
   Order.associate = (models) => {
@@ -25,6 +29,10 @@ module.exports = (sequelize, DataTypes) => {
       through: 'OrderMeals',
       as: 'meals',
       foreignKey: 'orderId'
+    });
+    Order.hasOne(models.DeliverOrder, {
+      foreignKey: 'orderId',
+      as: 'address'
     });
   };
   return Order;

--- a/src/models/user.js
+++ b/src/models/user.js
@@ -83,6 +83,10 @@ module.exports = (sequelize, DataTypes) => {
       as: 'roles',
       foreignKey: 'userId'
     });
+    User.hasMany(models.DeliverOrder, {
+      foreignKey: 'userId',
+      as: 'address'
+    });
   };
   return User;
 };

--- a/src/routes/order.js
+++ b/src/routes/order.js
@@ -6,15 +6,12 @@ import { PermissionsData } from '../utils';
 const router = Router();
 
 const { authenticate, isVerified } = AuthMiddleware;
+const { whitelist, orderChecks } = OrderMiddleware;
 const { verifyRoles } = UserMiddleware;
-const {
-  beforeCreatingOrder,
-} = OrderMiddleware;
-const {
-  createOrder,
-} = OrderController;
+const { clientOrder, serverOrder } = OrderController;
 const { admin, all } = PermissionsData;
-router.post('/', authenticate, verifyRoles(all), isVerified, beforeCreatingOrder, createOrder);
+router.post('/paystack/verify-client', authenticate, verifyRoles(all), isVerified, orderChecks, clientOrder);
+router.post('/paystack/verify-server', whitelist, orderChecks, serverOrder);
 
 
 export default router;

--- a/src/routes/pay.js
+++ b/src/routes/pay.js
@@ -8,7 +8,7 @@ const { authenticate, isVerified } = AuthMiddleware;
 const {
   withPaystack,
 } = PayController;
-router.get('/paystack', authenticate, isVerified, withPaystack);
+router.post('/paystack', authenticate, isVerified, withPaystack);
 // router.get('/paystack/status', payStatus);
 
 export default router;

--- a/src/services/cartService.js
+++ b/src/services/cartService.js
@@ -37,7 +37,7 @@ export default class CartService {
    * @memberof CartService
    */
   static async getMealsInCart(key) {
-    return Cart.findAll({ where: key });
+    return Cart.findAll({ raw: true, where: key });
   }
 
   /**

--- a/src/test/order.test.js
+++ b/src/test/order.test.js
@@ -3,7 +3,7 @@ import chai, { expect } from 'chai';
 import chaiHttp from 'chai-http';
 import server from '..';
 import {
-  userA, userInDatabase, removeUserFromDb, addMealToDb
+  userA, userInDatabase, removeUserFromDb, addMealToDb, addCartToDb
 } from './dummyData';
 
 chai.use(chaiHttp);
@@ -11,96 +11,120 @@ chai.use(chaiHttp);
 describe('Users can place orders', () => {
   let normalUser;
   let meal1;
-  let meal2;
   before(async () => {
     normalUser = await userInDatabase(userA, 3);
     meal1 = await addMealToDb({
       name: 'chicken pie',
       recipe: 'http://www.test.com',
-      price: 500,
+      price: 100,
       prepTime: '10 minutes',
       imageUrl: 'http://www.test.com'
     });
-    meal2 = await addMealToDb({
-      name: 'apple pie',
-      recipe: 'http://www.test.com',
-      price: 300,
-      prepTime: '10 minutes',
-      imageUrl: 'http://www.test.com'
+    await addCartToDb({
+      meals: [
+        { mealId: meal1.id, quantity: 10 },
+      ],
+      userId: normalUser.id,
     });
   });
   after(async () => {
     await removeUserFromDb({ id: normalUser.id });
   });
-  it('should successfully place an order if a user is logged in', async () => {
+  it('should successfully place an order via client side', async () => {
     const response = await chai
       .request(server)
-      .post('/v1.0/api/order')
+      .post('/v1.0/api/order/paystack/verify-client?reference=ekbgxzalif')
+      .set('Cookie', `token=${normalUser.token};`);
+    expect(response).to.have.status(201);
+    expect(response.body.status).to.equal('success');
+    expect(response.body.data).to.be.a('object');
+    expect(response.body.data.message).to.be.a('string');
+  }); // 7vv4mug68h
+  it('should fail client side if order status was abandoned or failed', async () => {
+    const response = await chai
+      .request(server)
+      .post('/v1.0/api/order/paystack/verify-client?reference=motfhd07br')
+      .set('Cookie', `token=${normalUser.token};`);
+    expect(response).to.have.status(400);
+    expect(response.body.status).to.equal('fail');
+    expect(response.body.error).to.be.a('object');
+  });
+  it('should fail if order with payment reference has been created', async () => {
+    const response = await chai
+      .request(server)
+      .post('/v1.0/api/order/paystack/verify-client?reference=ekbgxzalif')
+      .set('Cookie', `token=${normalUser.token};`);
+    expect(response).to.have.status(400);
+    expect(response.body.status).to.equal('fail');
+    expect(response.body.error).to.be.a('object');
+  });
+});
+
+describe('User can place orders via server api', () => {
+  let normalUser;
+  let meal1;
+  before(async () => {
+    normalUser = await userInDatabase(userA, 3);
+    meal1 = await addMealToDb({
+      name: 'chicken pie',
+      recipe: 'http://www.test.com',
+      price: 100,
+      prepTime: '10 minutes',
+      imageUrl: 'http://www.test.com'
+    });
+    await addCartToDb({
+      meals: [
+        { mealId: meal1.id, quantity: 10 },
+      ],
+      userId: normalUser.id,
+    });
+  });
+  after(async () => {
+    await removeUserFromDb({ id: normalUser.id });
+  });
+  it('should successfully place an order server-side', async () => {
+    const response = await chai
+      .request(server)
+      .post('/v1.0/api/order/paystack/verify-server')
       .set('Cookie', `token=${normalUser.token};`)
       .send({
-        meals: [
-          { mealId: meal1.id, quantity: 10 },
-          { mealId: meal2.id, quantity: 10 }
-        ]
+        event: 'charge.success',
+        data: {
+          id: 84,
+          domain: 'test',
+          status: 'success',
+          reference: '7vv4mug68h',
+          gateway_response: 'Approved',
+          metadata: {
+            userId: normalUser.id,
+            meals: [{ mealId: meal1.id, quantity: 10 }],
+            address: '123 corbin street, off apapa, lagos, nigeria',
+            price: 1000,
+          }
+        }
       });
     expect(response).to.have.status(201);
     expect(response.body.status).to.equal('success');
     expect(response.body.data).to.be.a('object');
     expect(response.body.data.message).to.be.a('string');
   });
-  it('should be unsuccessfull if the request is not authenticated ', async () => {
+  it('should fail if order with payment reference has been created', async () => {
     const response = await chai
       .request(server)
-      .post('/v1.0/api/order')
-      .send({
-        meals: [
-          { mealId: meal1.id, quantity: 10 },
-          { mealId: meal2.id, quantity: 10 }
-        ]
-      });
-    expect(response).to.have.status(401);
-    expect(response.body.status).to.equal('fail');
-  });
-  it('should be unsuccessfull if the meal id does not exist ', async () => {
-    const response = await chai
-      .request(server)
-      .post('/v1.0/api/order')
+      .post('/v1.0/api/order/paystack/verify-server')
       .set('Cookie', `token=${normalUser.token};`)
       .send({
-        meals: [
-          { mealId: 500000, quantity: 10 },
-          { mealId: meal2.id, quantity: 10 }
-        ]
+        event: 'charge.success',
+        data: {
+          id: 84,
+          domain: 'test',
+          status: 'success',
+          reference: '7vv4mug68h',
+          gateway_response: 'Approved',
+        }
       });
     expect(response).to.have.status(400);
     expect(response.body.status).to.equal('fail');
-  });
-  it('should be unsuccessfull if the meal id does not exist ', async () => {
-    const response = await chai
-      .request(server)
-      .post('/v1.0/api/order')
-      .set('Cookie', `token=${normalUser.token};`)
-      .send({
-        meals: [
-          { mealId: 500000, quantity: 10 },
-          { mealId: meal2.id, quantity: 10 }
-        ]
-      });
-    expect(response).to.have.status(400);
-    expect(response.body.status).to.equal('fail');
-  });
-  it('should be unsuccessfull if the request body is in the wrong format ', async () => {
-    const response = await chai
-      .request(server)
-      .post('/v1.0/api/order')
-      .set('Cookie', `token=${normalUser.token};`)
-      .send({
-        meals: [
-          { mealId: 500000, quantity: 'sjjdjs' },
-          { mealId: meal2.id, quantity: 10 }
-        ]
-      });
-    expect(response).to.have.status(400);
-    expect(response.body.status).to.equal('fail');
+    expect(response.body.error).to.be.a('object');
   });
 });

--- a/src/test/payment.test.js
+++ b/src/test/payment.test.js
@@ -32,11 +32,22 @@ describe('Pay for orders', () => {
   it('should successfully create paystack url for specific order', async () => {
     const response = await chai
       .request(server)
-      .get('/v1.0/api/pay/paystack')
-      .set('Cookie', `token=${normalUser.token};`);
+      .post('/v1.0/api/pay/paystack')
+      .set('Cookie', `token=${normalUser.token};`)
+      .send({ address: '123 corbin street, off apapa, lagos, nigeria' });
     expect(response).to.have.status(200);
     expect(response.body.status).to.equal('success');
     expect(response.body.data).to.be.a('object');
     expect(response.body.data.message).to.be.a('string');
+  });
+  it('should fail if input parameter is in wrong format', async () => {
+    const response = await chai
+      .request(server)
+      .post('/v1.0/api/pay/paystack')
+      .set('Cookie', `token=${normalUser.token};`)
+      .send({ address: 50 });
+    expect(response).to.have.status(400);
+    expect(response.body.status).to.equal('fail');
+    expect(response.body.error).to.be.a('object');
   });
 });

--- a/src/utils/payments.js
+++ b/src/utils/payments.js
@@ -8,24 +8,43 @@ const {
 const paystack = Paystack(PAYSTACK_TEST_SECRET_KEY);
 /**
  * Methods for payments class
- * payments use paystack
  * @class Payments
  */
 export default class Payments {
   /**
-   * validate user payments via paystack
+   * create user payment url via paystack
    * @param {obj} payload - { email, amount, }
-   * @returns {Promise<boolean>} - Returns true if mail is sent, false if not
+   * @returns {JSON} - Returns json with paystack url
    * @memberof Payments
    */
   static async viaPaystack(payload) {
-    const { email, amount } = payload;
+    const { email, amount, metadata } = payload;
     let stackBody;
     try {
       await paystack.transaction.initialize({
         email,
         amount,
+        metadata,
       }).then((body) => {
+        // console.log('paystack body: ', body);
+        stackBody = body;
+      });
+      return stackBody;
+    } catch (error) {
+      return error;
+    }
+  }
+
+  /**
+   * validate user payment via paystack
+   * @param {string} reference - paystack reference
+   * @returns {Promise<boolean>} - Returns json with payment details
+   * @memberof Payments
+   */
+  static async validatePaystack(reference) {
+    let stackBody;
+    try {
+      await paystack.transaction.verify(reference).then((body) => {
         // console.log('paystack body: ', body);
         stackBody = body;
       });

--- a/src/validations/index.js
+++ b/src/validations/index.js
@@ -4,6 +4,7 @@ import ProfileValidation from './profileValidation';
 import IngredientValidations from './ingredientValidation';
 import MealValidation from './mealValidation';
 import OrderValidation from './orderValidation';
+import PayValidation from './payValidation';
 
 
 export {
@@ -12,5 +13,6 @@ export {
   ProfileValidation,
   IngredientValidations,
   MealValidation,
-  OrderValidation
+  OrderValidation,
+  PayValidation,
 };

--- a/src/validations/payValidation.js
+++ b/src/validations/payValidation.js
@@ -1,0 +1,26 @@
+import joi from '@hapi/joi';
+
+
+const address = joi.string().min(3).max(200).regex(/^[\w',-\\/.\s]*$/)
+  .required()
+  .label('Please enter a strring');
+
+/**
+ * validation class for payments
+ * @class PayValidation
+ */
+export default class PayValidation {
+  /**
+   *
+   * @param {object} payload - object to be validated
+   * @returns {object | boolean} - returns an error object or valid boolean
+   */
+  static validateParameters(payload) {
+    const schema = {
+      address
+    };
+    const { error } = joi.validate({ ...payload }, schema);
+    if (error) throw error.details[0].context.label;
+    return true;
+  }
+}

--- a/swagger.json
+++ b/swagger.json
@@ -909,10 +909,49 @@
                 }
             }
         },
-        "/order": {
+        "/order/paystack/verify-client": {
             "post": {
-                "description": "make an order",
-                "summary": "A user can make an order",
+                "description": "create an order via client after paystack payment",
+                "summary": "User creates an order in client side after paystack payment",
+                "tags": [
+                    "Order"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "security": [
+                    {
+                        "Bearer": []
+                    }
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "reference",
+                        "required": true,
+                        "description": "paystack payment reference"
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "description": "Success"
+                    },
+                    "400": {
+                        "description": "Bad request"
+                    },
+                    "404": {
+                        "description": "Not found"
+                    },
+                    "401": {
+                        "description": "Authorization required"
+                    }
+                }
+            }
+        },
+        "/order/paystack/verify-server": {
+            "post": {
+                "description": "create an order via server after paystack payment",
+                "summary": "User creates an order in server side after paystack payment",
                 "tags": [
                     "Order"
                 ],
@@ -929,14 +968,14 @@
                         "in": "body",
                         "name": "body",
                         "required": true,
-                        "description": "This is the request body object containing the meals for the order",
+                        "description": "callback request body containing paystack payment details",
                         "schema": {
-                            "$ref": "#/requestBody/createOrder"
+                            "$ref": "#/requestBody/orderServer"
                         }
                     }
                 ],
                 "responses": {
-                    "200": {
+                    "201": {
                         "description": "Success"
                     },
                     "400": {
@@ -1105,27 +1144,120 @@
                     }
                 }
             }
+        },
+        "/pay/paystack": {
+            "post": {
+                "description": "pay for order via paystack",
+                "summary": "A user can pay for their order via paystack",
+                "tags": [
+                    "Pay"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "security": [
+                    {
+                        "Bearer": []
+                    }
+                ],
+                "parameters": [
+                    {
+                        "in": "body",
+                        "name": "body",
+                        "required": true,
+                        "description": "This is the request body object containing payment details",
+                        "schema": {
+                            "$ref": "#/requestBody/payOrder"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Success"
+                    },
+                    "400": {
+                        "description": "Bad request"
+                    },
+                    "404": {
+                        "description": "Not found"
+                    },
+                    "401": {
+                        "description": "Authorization required"
+                    }
+                }
+            }
         }
     },
     "requestBody": {
-        "createOrder": {
+        "orderServer": {
             "title": "User registration request",
             "type": "object",
             "properties": {
-                "meals": {
+                "event": {
+                    "description": "payment event",
+                    "type": "string"
+                },
+                "data": {
+                    "description": "payment data",
                     "schema": {
-                        "type": "array",
+                        "type": "object",
                         "items": {
-                            "type": "object"
+                            "status": {
+                                "description": "payment status",
+                                "type": "string"
+                            },
+                            "reference": {
+                                "desctription": "payment reference",
+                                "type": "string"
+                            },
+                            "gateway_response": {
+                                "desctription": "payment gateway response",
+                                "type": "string"
+                            },
+                            "metadata" : {
+                                "description": "order metadata",
+                                "type": "object",
+                                "items": {
+                                    "userId" : {
+                                        "description": "user id",
+                                        "type": "integer"
+                                    },
+                                    "meals": {
+                                        "description": "meals in order",
+                                        "schema": {
+                                            "type": "array",
+                                            "items": {
+                                                "type": "object"
+                                            }
+                                        }
+                                    },
+                                    "address": {
+                                        "description": "order delivery address",
+                                        "type": "string"
+                                    },
+                                    "price": {
+                                        "description": "price of order",
+                                        "type": "integer"
+                                    }
+                                }
+                            }
                         }
                     }
                 }
             },
             "example": {
-                "meals": [
-                    {"mealId":1, "quantity":10},
-                    {"mealId":2, "quantity":10}
-                    ]
+                "event": "charge.success",
+                "data": {
+                  "status": "success",
+                  "reference": "7vv4mug68h",
+                  "gateway_response": "Approved",
+                  "metadata": {
+                    "userId": 4,
+                    "meals": [{ "mealId": 3, "quantity": 10 }],
+                    "address": "123 corbin street, off apapa, lagos, nigeria",
+                    "price": 1000
+                  }
+                }
             },
             "required": [
                 "meals"
@@ -1454,6 +1586,22 @@
             "required": [
                 "mealId", "categoryId"
             ]
+        },
+        "payOrder": {
+            "title": "pay for order",
+            "type": "object",
+            "properties": {
+                "address": {
+                    "description": "address for delivery",
+                    "type": "string"
+                },
+                "example" :{
+                    "address":"123 corbin street, off apapa, lagos, nigeria"
+                },
+                "required": [
+                    "address"
+                ]
+            }
         }
     }
 }


### PR DESCRIPTION
#### What does this PR do?
- implements feature for creating an order after payments via client api and server web-hook, using its verify pay api (standard).

Descriptive docs for [paystack standard](https://developers.paystack.co/reference#paystack-standard-x)

#### Description of Task to be completed?
- Setup routes and order controllers
- Implement algorithm for creating orders and delivery data
- Test with postman
- Write unit tests

### Algorithm POST client side order creation
- Get reference from cleint
- Check if an order with reference has already been created
- verify reference via paystack payments verification object
- Create order on a successful payment
- Create delivery data
- Delete cart items for user. 

### Algorithm POST server side order creation
- Get request body from paystack after successful payment
- Check if request header has correct Whitelisted IP
- Check if order with reference has already been created
- Create order on successful payment
- Create delivery data
- Delete cart items for user.

### Testing
run `npm test`