### PR TITLE
Added Admin update order status

### DIFF
--- a/src/controllers/orderController.js
+++ b/src/controllers/orderController.js
@@ -8,7 +8,7 @@ const {
 } = Toolbox;
 
 const {
-  createOrder, createDelivery, getAllOrders
+  createOrder, createDelivery, getAllOrders, updateOrderStatus
 } = OrderService;
 const {
   deleteCartMealByKey,
@@ -110,14 +110,21 @@ export default class OrderController {
     }
   }
 
-  // /**
-  //   * get orders by status
-  //  * @param {object} req
-  //  * @param {object} res
-  //  * @returns {JSON } A JSON response with the created order.
-  //  * @memberof OrderController
-  // */
-  // static ordersByStatus(req, res) {
-
-  // }
+  /**
+    * update order status
+   * @param {object} req
+   * @param {object} res
+   * @returns {JSON } A JSON response with the created order.
+   * @memberof OrderController
+  */
+  static async updateStatus(req, res) {
+    try {
+      const id = Number(req.params.id);
+      const status = req.query;
+      const order = await updateOrderStatus(status, { id });
+      successResponse(res, { message: 'order successfully updated', order });
+    } catch (error) {
+      errorResponse(res, {});
+    }
+  }
 }

--- a/src/routes/order.js
+++ b/src/routes/order.js
@@ -6,12 +6,15 @@ import { PermissionsData } from '../utils';
 const router = Router();
 
 const { authenticate, isVerified } = AuthMiddleware;
-const { whitelist, orderChecks } = OrderMiddleware;
+const { whitelist, orderChecks, verifyParameters } = OrderMiddleware;
 const { verifyRoles } = UserMiddleware;
-const { clientOrder, serverOrder, viewOrders } = OrderController;
+const {
+  clientOrder, serverOrder, viewOrders, updateStatus
+} = OrderController;
 const { admin, all } = PermissionsData;
 router.post('/paystack/verify-client', authenticate, verifyRoles(all), isVerified, orderChecks, clientOrder);
 router.post('/paystack/verify-server', whitelist, orderChecks, serverOrder);
 router.get('/', authenticate, verifyRoles(admin), isVerified, viewOrders);
+router.patch('/:id', authenticate, verifyRoles(admin), isVerified, verifyParameters, updateStatus);
 
 export default router;

--- a/src/services/orderService.js
+++ b/src/services/orderService.js
@@ -59,18 +59,23 @@ export default class OrderService {
   }
 
   /**
-   * update an order given a key
-   * @param {object} updateData - data to update
+   * update order status
+   * @param {object} status - status to update
    * @param {object} keys - query key to update
    * @returns {promise-object | error} A promise object with order detail
    * @memberof OrderService
    */
-  static async updateOrderBykey(updateData, keys) {
-    const [rowaffected, [order]] = await Order.update(
-      updateData, { returning: true, where: keys }
-    );
-    if (!rowaffected) throw new ApiError(404, 'Not Found');
-    return order.dataValues;
+  static async updateOrderStatus(status, keys) {
+    try {
+      const [rowaffected, [order]] = await Order.update(
+        status, { returning: true, where: keys }
+      );
+      if (!rowaffected) throw new ApiError(404, 'Not Found');
+      return order.dataValues;
+    } catch (error) {
+      console.log('error: ', error);
+      throw new Error(error);
+    }
   }
 
   /**

--- a/src/services/orderService.js
+++ b/src/services/orderService.js
@@ -73,7 +73,6 @@ export default class OrderService {
       if (!rowaffected) throw new ApiError(404, 'Not Found');
       return order.dataValues;
     } catch (error) {
-      console.log('error: ', error);
       throw new Error(error);
     }
   }

--- a/src/test/order.test.js
+++ b/src/test/order.test.js
@@ -12,6 +12,7 @@ describe('Users can place orders', () => {
   let normalUser;
   let adminUser;
   let meal1;
+  let orderId;
   before(async () => {
     normalUser = await userInDatabase(userA, 3);
     adminUser = await userInDatabase(userB, 2);
@@ -60,11 +61,14 @@ describe('Users can place orders', () => {
     expect(response.body.status).to.equal('fail');
     expect(response.body.error).to.be.a('object');
   });
+
+  // TODO: move these admin actions to separate describe function
   it('should sucessfully get all orders by adim', async () => {
     const response = await chai
       .request(server)
       .get('/v1.0/api/order')
       .set('Cookie', `token=${adminUser.token};`);
+    orderId = response.body.data.orders[0].id;
     expect(response).to.have.status(200);
     expect(response.body.status).to.equal('success');
     expect(response.body.data).to.be.a('object');
@@ -78,6 +82,17 @@ describe('Users can place orders', () => {
     expect(response.body.status).to.equal('fail');
     expect(response.body.error.message).to.equal('Halt! You\'re not authorised');
   });
+
+  it('should sucessfully update order by adim', async () => {
+    const response = await chai
+      .request(server)
+      .patch(`/v1.0/api/order/${orderId}?status=completed`)
+      .set('Cookie', `token=${adminUser.token};`);
+    expect(response).to.have.status(200);
+    expect(response.body.status).to.equal('success');
+    expect(response.body.data).to.be.a('object');
+  });
+  // TODO: add more 'should' instances (failures).
 });
 
 describe('User can place orders via server api', () => {

--- a/src/validations/orderValidation.js
+++ b/src/validations/orderValidation.js
@@ -28,12 +28,29 @@ export default class OrderValidations {
     * validation for parameters on deleting a meal
     * @param {object} payload
     * @returns {object | boolean} - returns an error object or valid boolean
-    * @memberof MealValidation
+    * @memberof OrderValidations
     */
   static validateMeal(payload) {
     const schema = {
       mealId: joi.number().positive().required().label('Please enter a positive number'),
       quantity: joi.number().positive().label('Please enter a positive number'),
+    };
+    const { error } = joi.validate({ ...payload }, schema);
+    if (error) throw error.details[0].context.label;
+    return true;
+  }
+
+  /**
+   * validation for parameters on update of order status
+   * @param {object} payload
+    * @returns {object | boolean} - returns an error object or valid boolean
+    * @memberof OrderValidations
+   */
+  static validateParameters(payload) {
+    const schema = {
+      id: joi.number().positive().required().label('Please enter a positive number'),
+      status: joi.string().valid('pending', 'completed')
+        .label('please input a status (completed or pending)'),
     };
     const { error } = joi.validate({ ...payload }, schema);
     if (error) throw error.details[0].context.label;


### PR DESCRIPTION
## PR Overview
This PR adds features to allow an admin to update order status
Roles
- Admin

Also added
-  admin validations
- routes for update
- created order update controller
- user tests

### Algorithm on PATCH
- request sent to route
- verification and authentications are carried out
- soft validations carried on on body object (no required)
- check if order with id exists in database
- edit order via controller


## Testing
- Clone the repo and cd into the project folder
- Update or copy `.env` file from `.env.sample`
- Checkout to `ft-user-search` branch and run `npm install`
- Run `npm run migrate:reset` && `npm run migrate` to create tables in your 
 database and seed the database tables with the necessary app configs.
- Run `docker-compose up --build` to build the docker image and spin up all the necessary services
- As an alternative to running the app on docker, you can run `npm run start:dev`

###  PATCH
-`http://localhost:3000/v1.0/api/order/{id}?status=completed` 
- make sure an admin is already logged in with his/her token in the cookies.

*only works if order with id used exists in database. 