### PR TITLE
admin can view orders by status

### DIFF
--- a/src/controllers/orderController.js
+++ b/src/controllers/orderController.js
@@ -145,4 +145,22 @@ export default class OrderController {
       errorResponse(res, {});
     }
   }
+
+  /**
+   * get orders by status
+   * @param {object} req
+   * @param {object} res
+   * @returns {JSON } A JSON response with the created order.
+   * @memberof OrderController
+   */
+  static async viewOrdersByStatus(req, res) {
+    try {
+      const { status } = req.query;
+      const ordersByStatus = await findOrdersBykey({ status });
+      if (!ordersByStatus.length) return errorResponse(res, { code: 404, message: `There are no ${status} orders` });
+      return successResponse(res, { ...ordersByStatus });
+    } catch (error) {
+      errorResponse(res, {});
+    }
+  }
 }

--- a/src/middlewares/orderMiddleware.js
+++ b/src/middlewares/orderMiddleware.js
@@ -4,7 +4,7 @@ import { OrderValidation } from '../validations';
 
 const { errorResponse } = Toolbox;
 const { findOrder } = OrderService;
-const { validateParameters } = OrderValidation;
+const { validateParameters, validateQuery } = OrderValidation;
 const IP = ['52.31.139.75', '52.49.173.169', '52.214.14.220', '127.0.0.1'];
 /**
  * Middleware for order routes
@@ -67,10 +67,27 @@ export default class OrderMiddleware {
       const id = Number(req.params.id);
       validateParameters({
         id,
-        status: req.param.status,
+        status: req.params.status,
       });
       const orderInDatabase = await findOrder({ id });
       if (!orderInDatabase) return errorResponse(res, { code: 404, message: 'order does not exist in our database' });
+      next();
+    } catch (error) {
+      errorResponse(res, { code: 400, message: error });
+    }
+  }
+
+  /**
+   * order query check
+   * @param {object} req
+   * @param {object} res
+   * @param {object} next
+   * @returns {object} - return an object {error or response}
+   * @memberof OrderMiddleware
+   */
+  static async queryCheck(req, res, next) {
+    try {
+      validateQuery(req.query);
       next();
     } catch (error) {
       errorResponse(res, { code: 400, message: error });

--- a/src/routes/order.js
+++ b/src/routes/order.js
@@ -6,16 +6,20 @@ import { PermissionsData } from '../utils';
 const router = Router();
 
 const { authenticate, isVerified } = AuthMiddleware;
-const { whitelist, orderChecks, verifyParameters } = OrderMiddleware;
+const {
+  whitelist, orderChecks, verifyParameters, queryCheck
+} = OrderMiddleware;
 const { verifyRoles } = UserMiddleware;
 const {
-  clientOrder, serverOrder, viewOrders, updateStatus, getUserOrders
+  clientOrder, serverOrder, viewOrders, updateStatus, getUserOrders,
+  viewOrdersByStatus
 } = OrderController;
 const { admin, all } = PermissionsData;
 router.post('/paystack/verify-client', authenticate, verifyRoles(all), isVerified, orderChecks, clientOrder);
 router.post('/paystack/verify-server', whitelist, orderChecks, serverOrder);
 router.get('/all', authenticate, verifyRoles(admin), isVerified, viewOrders);
 router.get('/', authenticate, verifyRoles(all), isVerified, getUserOrders);
+router.get('/key', authenticate, verifyRoles(admin), isVerified, queryCheck, viewOrdersByStatus); // key?status=value
 router.patch('/:id', authenticate, verifyRoles(admin), isVerified, verifyParameters, updateStatus);
 
 export default router;

--- a/src/test/order.test.js
+++ b/src/test/order.test.js
@@ -82,6 +82,36 @@ describe('Users can place orders', () => {
     expect(response.body.status).to.equal('success');
     expect(response.body.data).to.be.a('object');
   });
+  it('should successfully get orders by status as admin', async () => {
+    const response = await chai
+      .request(server)
+      .get('/v1.0/api/order/key?status=pending')
+      .set('Cookie', `token=${adminUser.token};`);
+    expect(response).to.have.status(200);
+    expect(response.body.status).to.equal('success');
+    expect(response.body.data).to.be.a('object');
+  });
+  it('should return an error while getting orders by status if there are no orders', async () => {
+    const response = await chai
+      .request(server)
+      .get('/v1.0/api/order/key?status=completed')
+      .set('Cookie', `token=${adminUser.token};`);
+    expect(response).to.have.status(404);
+    expect(response.body.status).to.equal('fail');
+    expect(response.body.error).to.be.a('object');
+    expect(response.body.error.message).to.equal('There are no completed orders');
+  });
+  it('should return an error while getting orders if status parameter is wrong', async () => {
+    const response = await chai
+      .request(server)
+      .get('/v1.0/api/order/key?status=boogie')
+      .set('Cookie', `token=${adminUser.token};`);
+    expect(response).to.have.status(400);
+    expect(response.body.status).to.equal('fail');
+    expect(response.body.error).to.be.a('object');
+    expect(response.body.error.message).to.equal('please input a status (completed or pending)');
+  });
+
   it('should return an error if a user is unauthorized', async () => {
     const response = await chai
       .request(server)

--- a/src/validations/orderValidation.js
+++ b/src/validations/orderValidation.js
@@ -56,4 +56,20 @@ export default class OrderValidations {
     if (error) throw error.details[0].context.label;
     return true;
   }
+
+  /**
+   * validate query parameters
+   * @param {object} payload
+   * @returns {object | boolean} - returns an error object or valid boolean
+   * @memberof OrderValidations
+   */
+  static validateQuery(payload) {
+    const schema = {
+      status: joi.string().valid('pending', 'completed')
+        .label('please input a status (completed or pending)'),
+    };
+    const { error } = joi.validate({ ...payload }, schema);
+    if (error) throw error.details[0].context.label;
+    return true;
+  }
 }


### PR DESCRIPTION
## PR Overview
This PR adds features to allow admin to get all orders by status (pending, completed

## Testing
- Clone the repo and cd into the project folder
- Update or copy `.env` file from `.env.sample`
- Checkout to `ft-user-search` branch and run `npm install`
- Run `npm run migrate:reset` && `npm run migrate` to create tables in your 
 database and seed the database tables with the necessary app configs.
- Run `docker-compose up --build` to build the docker image and spin up all the necessary services
- As an alternative to running the app on docker, you can run `npm run start:dev`

### GET
-`http://localhost:3000/v1.0/api/order/key?status=completed` 
- make sure an admin is already logged in with his/her token in the cookies.